### PR TITLE
Stability fixes, improve error classification, checkpoint handling, and backend reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ tests/**/*.pkcs12
 .pytest_cache/
 python/mq-bridge-py/.venv/
 python/mq-bridge-py/dist/
+
+# Local build setup (shared cargo target dir with mq-bridge-app), not for git
+.cargo/
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2977,6 +2977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libmqm-constants"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3207,15 @@ dependencies = [
  "rand_xoshiro",
  "rapidhash",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3431,6 +3449,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "fast-uuid-v7",
+ "mimalloc",
  "mq-bridge",
  "mq-bridge-bindings-common",
  "napi",
@@ -3452,6 +3471,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "fast-uuid-v7",
+ "mimalloc",
  "mq-bridge",
  "mq-bridge-bindings-common",
  "pyo3",
@@ -4503,7 +4523,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -4542,9 +4562,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5044,7 +5064,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5140,7 +5160,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6040,10 +6060,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6913,7 +6933,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3725,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "omq-proto"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9335ef21d570294464c491837af5477caddb05cf3c7223af1c4341a127e6035"
+checksum = "856d18f6b58f39153fcf0b574efe3f04362ff44d3a46829eb984c1f9ef2d121c"
 dependencies = [
  "bytes",
  "patricia_tree",
@@ -3739,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "omq-tokio"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9d9c6caa88d29df5b9dc9638ea9f0f33b087ecc0f149b70e61149f97bcdb80"
+checksum = "98aaa33702e7d723de268dd9fe725f93d469afef3f1bedb14cfa7f579f61a7b7"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -4503,7 +4503,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -4542,9 +4542,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5140,7 +5140,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6040,10 +6040,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6913,7 +6913,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7191,9 +7191,9 @@ dependencies = [
 
 [[package]]
 name = "yring"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39146d2147cfb9f71b9f071f93f7b5dbcfb28eee528dafcaf5f500f4917cb69f"
+checksum = "f8545becda6379f37e13fbdf5d9de464849bdd1565a995368648f11fe9d96d13"
 dependencies = [
  "loom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "mq-bridge"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "mq-bridge-bindings-common"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "fast-uuid-v7",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "mq-bridge-node"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "mq-bridge-py"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["bindings-common", "python/mq-bridge-py", "node/mq-bridge-node"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ float-roundtrip = ["serde_json/float_roundtrip"]
 # runtime the client is loaded lazily only when an ibm-mq endpoint is opened
 # (clear error if the client isn't installed). Use `ibm-mq-static` instead for
 # static linking.
-full = ["middleware", "mongodb", "kafka", "amqp", "nats", "mqtt", "http", "aws", "zeromq", "redis-streams", "sled", "grpc", "sqlx", "clickhouse", "websocket", "postgres-cdc", "object-store", "rustls-aws-lc", "ibm-mq"]
+full = ["middleware", "mongodb", "kafka", "amqp", "nats", "mqtt", "http", "aws", "zeromq", "zeromq-omq", "redis-streams", "sled", "grpc", "sqlx", "clickhouse", "websocket", "postgres-cdc", "object-store", "rustls-aws-lc", "ibm-mq"]
 
 # Endpoints that build across most OS targets (glibc/musl/Alpine, macOS,
 # Windows, aarch64/armv7) without a special toolchain — no librdkafka, protoc,

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you need to move data reliably between systems and you write code (Rust, Pyth
 *   **TLS everywhere, one config shape**: a single `TlsConfig` block (CA bundle, client cert/key for mTLS, insecure-skip) is reused across transports.
 *   **Self-hosted, no daemon**: generate config in the optional UI, paste it into your code, run it in-process. No hosted control plane, no separate scheduler.
 
-> **Throughput & footprint.** In our own benchmarks, the same engine — driven the zero-code way through [`mq-bridge-app`](https://github.com/marcomq/mq-bridge-app) — sustained ~267,000 rows/s copying 1,000,000 rows from Postgres to JSONL on commodity hardware at **~20 MiB peak RSS**, keeping it well in the range of dedicated data-movement tools. On a CSV→JSONL file conversion (1,000,000 mixed-type rows, ~116 MiB), it sustained **833,333 rows/s** at the same ~20 MiB, about **~43x faster** and **~22x leaner in memory** than Meltano (`tap-csv` → `target-jsonl`, ~19,500 rows/s / ~444 MiB). Full setup, methodology, and the exact parameters are in [`benches/ETL_BENCHMARKS.md`](benches/ETL_BENCHMARKS.md).
+> **Throughput & footprint.** In our own benchmarks, the same engine — driven the zero-code way through [`mq-bridge-app`](https://github.com/marcomq/mq-bridge-app) — on a CSV→JSONL file conversion (1,000,000 mixed-type rows, ~116 MiB) sustained **1,133,786 rows/s** at ~22 MiB, about **~58x faster** and **~20x leaner in memory** than Meltano (`tap-csv` → `target-jsonl`, ~19,500 rows/s / ~444 MiB). Full setup, methodology, and the exact parameters are in [`benches/ETL_BENCHMARKS.md`](benches/ETL_BENCHMARKS.md).
 
 
 ## Language Bindings

--- a/README.md
+++ b/README.md
@@ -306,9 +306,14 @@ server-side (default one-hour window) — `insert_deduplication_token` lets you 
 mq-bridge does not set one, so rely on `ReplacingMergeTree` for logical dedup and treat block-level
 dedup only as retry-safety.
 
-**Postgres CDC — deterministic id + `postgres.key`.** The `postgres_cdc` source already resumes from a
-durable LSN checkpoint (no re-delivery on clean restart). For the crash window (row written, then a
-crash before the checkpoint flush) it is at-least-once, so make the sink idempotent. Each change event
+**Postgres CDC — deterministic id + `postgres.key`.** The `postgres_cdc` source resumes from the slot's
+durable `confirmed_flush_lsn`. In-band standby feedback is asynchronous and is *not* flushed when the
+stream stops, so the last acks are made durable by the consumer's `Drop`, which stops the stream and
+advances the slot synchronously. Re-delivery is therefore avoided only on a restart that actually runs
+that teardown — a host process that exits without dropping the route (or one on a current-thread Tokio
+runtime, where the blocking advance is skipped) replays everything since the last asynchronous feedback
+tick. Set `checkpoint_store` to a `file://` path for a second, per-ack durable position that survives
+teardown regardless. Treat the source as at-least-once and make the sink idempotent. Each change event
 carries the full row (so the primary key is in the payload), `postgres.lsn` (a monotonic version),
 `postgres.operation`/`schema`/`table`, and — when the table has a primary key / replica identity —
 `postgres.key` (the key value). The event's `message_id` is a stable hash of `schema.table + key +

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -240,8 +240,10 @@ feature (pulls `sled`).
 
 - `sled:///path` (or a bare path) — a local sled database; per-process, not cluster-wide.
 - `mongodb://host/db[/collection]` — a shared collection, so multiple instances of a route
-  deduplicate against one another. Requires the `mongodb` feature. Entries expire via a
-  MongoDB TTL index; the collection defaults to `mqb_dedup_<route>`. Point it at the same
+  deduplicate against one another. Requires the `mongodb` feature. Expiry is judged on read,
+  so a `ttl_seconds` boundary is honoured exactly; the TTL index only reclaims space
+  afterwards (MongoDB's sweep can lag by up to a minute). The collection defaults to
+  `mqb_dedup_<route>`. Point it at the same
   deployment your sink already uses to avoid running extra infrastructure.
 - `postgres|mysql|mariadb|sqlite://…[/table]` — a shared SQL table (`dedup_key` PK,
   `expire_at`), so multiple instances deduplicate against one another. Requires the `sqlx`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -38,6 +38,11 @@ layer and sees the failures of the ones before it.** Put `dlq` last.
 **Input (consumer) middlewares are applied in reverse, so the *first* entry is outermost**
 and runs first on an incoming message.
 
+**Consequence: a route that reads back what another route wrote needs the *reversed* list.**
+Writing with `[compression, encryption]` produces `compress(encrypt(payload))`; a reader
+given that same list would try to decrypt first and fail. The reading route must say
+`[encryption, compression]`. The lists mirror — they are not copied.
+
 > This is asserted by `route::tests::test_dlq_and_retry_batch_integration`,
 > `middleware::transform::tests::test_rejected_message_reaches_the_dlq_through_the_config_wiring`,
 > and `reference_docs_test::publisher_middleware_wraps_last_entry_outermost`, and is
@@ -58,7 +63,7 @@ middlewares:
 | [`retry`](#retry) | – | ✅ | – | Exponential-backoff retry of failed sends |
 | [`dlq`](#dlq) | – | ✅ | – | Route permanently-failed messages to another endpoint |
 | [`transform`](#transform) | ✅ | ✅ | – | Declarative JSON mapping, coercion, validation |
-| [`deduplication`](#deduplication) | ✅ | – | `dedup` | Drop repeated message IDs within a TTL |
+| [`deduplication`](#deduplication) | ✅ | – | `dedup` | Drop repeated keys within a TTL |
 | [`weak_join`](#weak_join) | ✅ | – | – | Correlate and join related messages |
 | [`buffer`](#buffer) | ✅ | ✅ | – | Coalesce single sends into batches |
 | [`limiter`](#limiter) | ✅ | ✅ | – | Cap throughput to a message rate |
@@ -227,7 +232,7 @@ with neither stage configured leaves the payload untouched without parsing it.
 
 ### `deduplication`
 
-Drops messages whose ID was already seen within the TTL. Input only. Requires the `dedup`
+Drops messages whose key was already seen within the TTL. Input only. Requires the `dedup`
 feature (pulls `sled`).
 
 | Field | Type | Required |
@@ -235,6 +240,13 @@ feature (pulls `sled`).
 | `store` | string | one of `store`/`sled_path` |
 | `sled_path` | string | one of `store`/`sled_path` |
 | `ttl_seconds` | integer | yes |
+| `key` | string | no (defaults to `message_id`) |
+
+`key` is an interpolation template (see `${namespace:selector}`), typically
+`"${payload:order_id}"`. Without it the key is the `message_id`, which most sources
+regenerate on every read — so re-reading the same source deduplicates nothing and only
+in-flight redeliveries are suppressed. Set `key` to a business key whenever you need
+dedup to survive a re-read.
 
 `store` selects the backend by URL scheme:
 
@@ -262,6 +274,10 @@ feature (pulls `sled`).
 
 ```yaml middleware
 - deduplication: { store: "postgres://user:pass@localhost/etl", ttl_seconds: 3600 }
+```
+
+```yaml middleware
+- deduplication: { store: "sled:///var/lib/mq-bridge/dedup", ttl_seconds: 3600, key: "${payload:order_id}" }
 ```
 
 When MongoDB is your sink and messages carry a business key, prefer the sink's own unique

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -17,7 +17,7 @@ endpoints, shape routing, or terminate a request. Data endpoints (`kafka`, `nats
 Middleware attaches to an endpoint via a `middlewares:` list, on the **input**, the
 **output**, or both:
 
-```yaml
+```yaml route
 my_route:
   input:
     middlewares:
@@ -103,7 +103,7 @@ Retries failed sends with exponential backoff. Output only.
 | `max_interval_ms` | integer | `5000` |
 | `multiplier` | float | `2.0` |
 
-```yaml
+```yaml middleware
 - retry: { max_attempts: 5, initial_interval_ms: 200, max_interval_ms: 10000, multiplier: 2.0 }
 ```
 
@@ -119,7 +119,7 @@ Sends permanently-failed messages to a separate endpoint instead of failing the 
 |---|---|---|
 | `endpoint` | Endpoint | yes |
 
-```yaml
+```yaml middleware
 - dlq:
     endpoint:
       file: { path: "dead-letters.jsonl" }
@@ -161,7 +161,7 @@ validation — over a single parse. Input and output.
 `schema` and `schema_file` are mutually exclusive. A mapping rule is either a bare path
 string or `{ path, default, required }`.
 
-```yaml
+```yaml middleware
 - transform:
     mapping:
       firstName: "$.first_name"
@@ -185,7 +185,7 @@ lossless ones: `string → integer`, `string → number`, `string → boolean` (
 A field carrying a JSON document as a string is decoded by `contentMediaType`, following
 JSON Schema 2020-12:
 
-```yaml
+```yaml middleware
 - transform:
     schema:
       type: object
@@ -252,15 +252,15 @@ feature (pulls `sled`).
 
 `sled_path` is the legacy spelling of a local sled store and is equivalent to `store: "sled://<path>"`.
 
-```yaml
+```yaml middleware
 - deduplication: { store: "sled:///var/lib/mq-bridge/dedup", ttl_seconds: 3600 }
 ```
 
-```yaml
+```yaml middleware
 - deduplication: { store: "mongodb://localhost:27017/etl", ttl_seconds: 3600 }
 ```
 
-```yaml
+```yaml middleware
 - deduplication: { store: "postgres://user:pass@localhost/etl", ttl_seconds: 3600 }
 ```
 
@@ -281,7 +281,7 @@ Correlates messages by a metadata key and emits them as one joined message. Inpu
 | `required` | list of branch names | `[]` |
 | `on_timeout` | `fire` \| `discard` | `fire` |
 
-```yaml
+```yaml middleware
 # Count mode: wait for any 3 messages sharing a correlation_id, emit a JSON array.
 - weak_join: { group_by: "correlation_id", expected_count: 3, timeout_ms: 5000 }
 
@@ -309,7 +309,7 @@ Accumulates single sends and forwards them as one batch. Input and output.
 | `max_messages` | integer | yes |
 | `max_delay_ms` | integer | yes |
 
-```yaml
+```yaml middleware
 - buffer: { max_messages: 500, max_delay_ms: 20 }
 ```
 
@@ -324,7 +324,7 @@ Paces throughput to a target rate. Input and output.
 |---|---|---|
 | `messages_per_second` | float (> 0) | yes |
 
-```yaml
+```yaml middleware
 - limiter: { messages_per_second: 250 }
 ```
 
@@ -338,7 +338,7 @@ Sleeps a fixed duration before each receive or send. Input and output.
 |---|---|---|
 | `delay_ms` | integer | yes |
 
-```yaml
+```yaml middleware
 - delay: { delay_ms: 100 }
 ```
 
@@ -358,7 +358,7 @@ Persists HTTP cookies and arbitrary session values across messages. Input and ou
 | `export_metadata_prefix` | string | – |
 | `inject_metadata` | map string→string | `{}` |
 
-```yaml
+```yaml middleware
 - cookie_jar:
     shared_scope: "login-session"
     capture_metadata_keys: ["x-csrf-token"]
@@ -382,7 +382,7 @@ output. Requires the `encryption` feature.
 | `key` | string — base64-encoded 32-byte key; `${env:VAR}` reads it from the environment | required |
 | `decrypt_keys` | map key_id → key | `{}` |
 
-```yaml
+```yaml middleware
 - encryption: { key: "${env:MQB_ENC_KEY}" }
 ```
 
@@ -404,7 +404,7 @@ Do **not** combine this middleware with a sink's batch `compression` on the same
 ciphertext does not compress. For compressed *and* encrypted data at rest, use the `file` /
 `object_store` endpoints' own fields instead, which apply compress-then-encrypt per batch:
 
-```yaml
+```yaml endpoint
 output:
   file:
     path: "data.enc"
@@ -445,7 +445,7 @@ feature.
 | `algorithm` | `none` \| `gzip` \| `lz4` \| `zstd` | `zstd` |
 | `max_decompressed_bytes` | integer — reject a payload that decompresses larger than this (bomb guard); consumer side only | unset (no limit) |
 
-```yaml
+```yaml middleware
 - compression: { algorithm: zstd }
 ```
 
@@ -466,7 +466,7 @@ endpoints' own `compression`/`encryption` fields instead.
 Emits throughput, latency and error metrics for the endpoint. Input and output. Requires the
 `metrics` feature. Takes no options; its presence enables collection.
 
-```yaml
+```yaml middleware
 - metrics: {}
 ```
 
@@ -482,13 +482,31 @@ Deliberate fault injection for testing recovery paths. Input and output.
 | `trigger_on_message` | integer (1-indexed) | – (every message) |
 | `enabled` | bool | `true` |
 
-```yaml
+```yaml middleware
 - random_panic: { mode: disconnect, trigger_on_message: 500 }
 ```
 
 `disconnect` and `timeout` produce retryable errors; `json_format_error` produces a
 non-retryable one — useful for exercising a `dlq`. Keep `enabled: false` in committed configs
 rather than deleting the block.
+
+The middleware block alone is **not** enough: fault injection is gated per route by
+`allow_fault_injection`, which defaults to `false`. Copying only the snippet above leaves the
+middleware inert (the route logs that it is disabled). A complete, working configuration:
+
+```yaml route
+flaky_test_route:
+  allow_fault_injection: true
+  input:
+    memory: { topic: "in" }
+    middlewares:
+      - random_panic: { mode: disconnect, trigger_on_message: 500 }
+  output:
+    memory: { topic: "out" }
+```
+
+`allow_fault_injection: true` is intended for test configurations only. Do not enable it — or
+the `random_panic` middleware — in production configs.
 
 ### `custom` (middleware)
 
@@ -499,7 +517,7 @@ Delegates to a factory you registered programmatically.
 | `name` | string | yes |
 | `config` | any JSON | yes |
 
-```yaml
+```yaml middleware
 - custom:
     name: "my_enricher"
     config: { lookup_url: "http://enrich.internal" }
@@ -547,7 +565,7 @@ use mq_bridge::route::register_endpoint;
 register_endpoint("common_queue", Endpoint::new_memory("shared_memory_topic", 100));
 ```
 
-```yaml
+```yaml route
 enrich:
   input: { ref: "common_queue" }
   output: { nats: { subject: "enriched", url: "nats://localhost:4222" } }
@@ -566,7 +584,7 @@ nesting depth is bounded.
 
 Publishes each message to every listed endpoint. Output only.
 
-```yaml
+```yaml endpoint
 output:
   fanout:
     - kafka: { topic: "audit", url: "localhost:9092" }
@@ -587,7 +605,7 @@ Content-based routing: picks a destination by the value of a **metadata key**.
 | `cases` | map value → Endpoint | yes |
 | `default` | Endpoint | no |
 
-```yaml
+```yaml endpoint
 output:
   switch:
     metadata_key: "http_status_code"
@@ -613,7 +631,7 @@ turning a request/reply exchange into a one-way flow.
 | `to` | Endpoint (request-capable) | yes |
 | `forward_to` | Endpoint | yes |
 
-```yaml
+```yaml endpoint
 output:
   request:
     to: { http: { url: "https://api.internal/score" } }
@@ -630,7 +648,7 @@ status key such as `http_status_code`.
 Replies to the origin of the current request. Output only, and the recommended way to build
 request/reply routes.
 
-```yaml
+```yaml route
 http_echo:
   input: { http: { url: "0.0.0.0:8080" } }
   output: { response: {} }
@@ -646,7 +664,7 @@ pipeline. See [README.md](README.md#patterns-request-response).
 An output endpoint that **ignores the incoming payload** and instead reads one message from
 the wrapped consumer, returning it as the response. The inbound message is purely a trigger.
 
-```yaml
+```yaml route
 # HTTP GET pulls the next message off a Kafka topic.
 poll_api:
   input: { http: { url: "0.0.0.0:8080", method: "GET" } }
@@ -672,7 +690,7 @@ source).
 
 Accepts either a bare string or the full map form:
 
-```yaml
+```yaml endpoint
 output: { static: "OK" }                       # shorthand, body JSON-encoded
 
 output:
@@ -709,7 +727,7 @@ structure — append `| raw` to a token to splice it verbatim. To emit a literal
 `${…}`, write `$${…}` (a bare `$$` is left as-is); any `${…}` with an unknown namespace is also
 left untouched.
 
-```yaml
+```yaml endpoint
 output:
   static:
     body: '{"error":"not found","id":"${message:id}","at":"${gen:now}"}'
@@ -728,7 +746,7 @@ bodies between routes.
 | `correlation_id` | string | **required on consumers, must be unset on publishers** |
 | `capacity` | integer | default `100`, per partition |
 
-```yaml
+```yaml endpoint
 output:
   stream_buffer: { topic: "responses" }        # publisher: no correlation_id
 
@@ -743,7 +761,7 @@ and ignores it. Primarily wired up via `HttpConfig::stream_response_to`.
 
 Discards every message. Output only. This is the **default output** when a route omits one.
 
-```yaml
+```yaml route
 drain:
   input: { kafka: { topic: "noisy", url: "localhost:9092" } }
   output: null          # a bare YAML null
@@ -764,7 +782,7 @@ Delegates to a factory you registered programmatically.
 | `name` | string | yes |
 | `config` | any JSON | yes |
 
-```yaml
+```yaml endpoint
 output:
   custom:
     name: "my_sink"

--- a/benches/ETL_BENCHMARKS.md
+++ b/benches/ETL_BENCHMARKS.md
@@ -72,7 +72,7 @@ theirs. The run brief lives in [`mq-bridge-app-benchmark-prompt.md`](mq-bridge-a
 
 | Scenario | Payload | Batch | Concurrency | Source → Sink | Result |
 | --- | --- | --- | --- | --- | --- |
-| Bulk-copy throughput | 7-col mixed-type rows, 1,000,000 rows | 1024 | 4 | postgres (keyset cursor) → file (JSONL) | **303,398 rows/s** (3.296 s) |
+| Bulk-copy throughput | 7-col mixed-type rows, 1,000,000 rows | 1024 | 4 | postgres (keyset cursor) → file (JSONL) | **384,615 rows/s** (2.600 s) |
 
 Command: `mq-bridge-app copy --from postgres://…?table=…&cursor_column=id --to file://…?format=raw --drain --batch-size 1024 --concurrency 4`, wall-clocked. Requires an index on the cursor column (`CREATE INDEX ON <table>(id)`) — without it the keyset-pagination reader (`WHERE id > $cursor ORDER BY id LIMIT batch`) does a full scan per batch (near-quadratic).
 
@@ -82,10 +82,10 @@ Same source table (`bench`: 1,000,000 rows, 7 mixed-type columns), same Postgres
 
 | Scenario | Payload | Batch | Concurrency | Source → Sink | Throughput | Peak RSS |
 | --- | --- | --- | --- | --- | --- | --- |
-| mq-bridge-app `copy` | 7-col, 1,000,000 rows | 1024 | 1 | postgres (keyset cursor) → file (JSONL) | **266,951 rows/s** | 19.9 MiB |
+| mq-bridge-app `copy` | 7-col, 1,000,000 rows | 1024 | 1 | postgres (keyset cursor) → file (JSONL) | **338,066 rows/s** | 39.8 MiB |
 | Meltano (`tap-postgres` → `target-jsonl`) | 7-col, 1,000,000 rows | default Singer config | — | postgres → JSONL | 15,356 rows/s | 599.7 MiB |
 
-**~17.4x faster and ~30x leaner in peak memory** than Meltano in this scenario. Full setup (including the Meltano project config) is in [mq-bridge-app's `benches/etl/README.md`](https://github.com/marcomq/mq-bridge-app/blob/dev/benches/etl/README.md#5--postgres--jsonl-vs-meltano-tap-postgres--target-jsonl).
+**~22x faster and ~15x leaner in peak memory** than Meltano in this scenario. Full setup (including the Meltano project config) is in [mq-bridge-app's `benches/etl/README.md`](https://github.com/marcomq/mq-bridge-app/blob/dev/benches/etl/README.md#5--postgres--jsonl-vs-meltano-tap-postgres--target-jsonl).
 
 ### Preliminary run — CSV → JSONL vs. Meltano
 
@@ -93,10 +93,10 @@ Same seeded dataset both sides, same machine, one-shot full-file CSV → local J
 
 | Scenario | Payload | Batch | Concurrency | Source → Sink | Throughput | Peak RSS |
 | --- | --- | --- | --- | --- | --- | --- |
-| mq-bridge-app `copy` | 7-col mixed-type, 1,000,000 rows (~116 MiB) | 1024 | 1 | file (CSV) → file (JSONL) | **833,333 rows/s** | 20.0 MiB |
+| mq-bridge-app `copy` | 7-col mixed-type, 1,000,000 rows (~116 MiB) | 1024 | 1 | file (CSV) → file (JSONL) | **1,133,786 rows/s** | 21.9 MiB |
 | Meltano (`tap-csv` → `target-jsonl`) | 7-col mixed-type, 1,000,000 rows | default Singer config | — | file (CSV) → JSONL | ~19,500 rows/s | 443.8 MiB |
 
-**~43x faster and ~22x leaner in peak memory** than Meltano in this scenario. Full setup is in [mq-bridge-app's `benches/etl/README.md`](https://github.com/marcomq/mq-bridge-app/blob/dev/benches/etl/README.md#6--csv--jsonl-vs-meltano).
+**~58x faster and ~20x leaner in peak memory** than Meltano in this scenario. Full setup is in [mq-bridge-app's `benches/etl/README.md`](https://github.com/marcomq/mq-bridge-app/blob/dev/benches/etl/README.md#6--csv--jsonl-vs-meltano).
 
 ## Status
 

--- a/mq-bridge.schema.json
+++ b/mq-bridge.schema.json
@@ -478,6 +478,14 @@
       "description": "Deduplication middleware configuration.\n\nPrevents duplicate messages from being processed using a sled, MongoDB, or SQL backend.\nMessages are identified by their deduplication key and removed after the TTL expires.",
       "type": "object",
       "properties": {
+        "key": {
+          "description": "Dedup key template, e.g. `${payload:order_id}`. Defaults to `message_id`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
         "sled_path": {
           "description": "Local Sled directory (legacy). Prefer `store`.",
           "type": [

--- a/mq-bridge.schema.json
+++ b/mq-bridge.schema.json
@@ -922,9 +922,16 @@
           ]
         },
         {
-          "type": "string",
+          "type": "object",
           "format": "structural_endpoint",
-          "const": "null"
+          "properties": {
+            "null": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "null"
+          ]
         }
       ],
       "unevaluatedProperties": false
@@ -963,7 +970,7 @@
       "type": "object",
       "properties": {
         "compression": {
-          "description": "Per-batch compression (`none`, `gzip`, `lz4`, `zstd`). Requires the `compression` feature; consume mode only.",
+          "description": "Per-batch compression (`none`, `gzip`, `lz4`, `zstd`). Requires the `compression` feature. Publishers: always. Consumers: must match, and only the default `consume` mode reads it.",
           "$ref": "#/$defs/Compression",
           "default": "none"
         },
@@ -975,7 +982,7 @@
           ]
         },
         "encryption": {
-          "description": "At-rest AEAD encryption applied after compression. Requires the `encryption` feature; consume mode only.",
+          "description": "At-rest AEAD encryption applied after compression. Requires the `encryption` feature. Publishers: always. Consumers: must match, and only the default `consume` mode reads it.",
           "anyOf": [
             {
               "$ref": "#/$defs/EncryptionConfig"
@@ -2609,7 +2616,7 @@
           "minimum": 0
         },
         "temporary_slot": {
-          "description": "Use a temporary slot (dropped on disconnect). Not restart-safe; default is a permanent slot.",
+          "description": "Ephemeral run: drop the slot when the route stops. Not restart-safe; a hard crash leaks it.",
           "type": "boolean",
           "default": false
         },

--- a/node/mq-bridge-node/Cargo.toml
+++ b/node/mq-bridge-node/Cargo.toml
@@ -24,9 +24,19 @@ napi-derive = "3"
 schemars = { version = "1.2", optional = true }
 serde_json.workspace = true
 serde_yaml_ng.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "env-filter"] }
+
+# The addon is dlopen'd by Node, so mimalloc's thread-locals must use the dynamic
+# TLS model — the default initial-exec model draws from the fixed static TLS
+# surplus and fails to load on slim images ("cannot allocate memory in static TLS
+# block", napi-rs#1060). Not applicable on macOS/Windows.
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+mimalloc = { version = "0.1", default-features = false, features = ["local_dynamic_tls"], optional = true }
+
+[target.'cfg(not(any(target_os = "linux", target_os = "freebsd")))'.dependencies]
+mimalloc = { version = "0.1", default-features = false, optional = true }
 
 [build-dependencies]
 napi-build = "2"
@@ -34,7 +44,11 @@ napi-build = "2"
 [features]
 default = ["full"]
 middleware = ["mq-bridge/middleware"]
-full = ["mq-bridge/full", "schema"]
+full = ["mq-bridge/full", "schema", "mimalloc"]
+# mimalloc as Rust-side global allocator. Only redirects allocations made by this
+# cdylib's Rust code; V8's allocator is untouched. Safe because no raw
+# Rust-allocated buffer crosses the addon boundary. Excluded from `basic`.
+mimalloc = ["dep:mimalloc"]
 basic = ["http", "nats", "mqtt", "websocket", "zeromq", "rustls-ring", "schema"]
 dedup = ["mq-bridge/dedup"]
 metrics = ["mq-bridge/metrics"]

--- a/node/mq-bridge-node/src/lib.rs
+++ b/node/mq-bridge-node/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -27,6 +31,9 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 #[napi(js_name = "version")]
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// How often a blocking `join()` checks whether the route ended on its own.
+const ROUTE_END_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 /// JSON Schema for the route/config mapping, generated on demand from the
 /// compiled Rust models (no checked-in copy, so it cannot drift).
@@ -256,6 +263,10 @@ struct RouteRunState {
     running: bool,
     stop_tx: Option<oneshot::Sender<()>>,
     join_handle: Option<thread::JoinHandle<()>>,
+    /// Set when a route started with `start()` ended on a permanent failure, so
+    /// `join()` can report the cause instead of returning as if it had stopped
+    /// cleanly. Taken by `join()`.
+    failure: Option<String>,
 }
 
 #[napi]
@@ -394,10 +405,17 @@ impl Route {
             .name(format!("mqb-node-route-{name}"))
             .spawn(move || {
                 let stop_name = wait_name.clone();
-                runtime.block_on(async move {
-                    let _ = stop_rx.await;
+                let result = runtime.block_on(async move {
+                    let outcome = wait_for_stop_or_end(&stop_name, stop_rx).await;
+                    let result = outcome_to_result(&stop_name, outcome);
                     core::Route::stop(&stop_name).await;
+                    result
                 });
+                if let Err(err) = result {
+                    if let Ok(mut state) = wait_run_state.lock() {
+                        state.failure = Some(err.to_string());
+                    }
+                }
                 finish_run(&wait_run_state, &wait_name);
             }) {
             Ok(handle) => handle,
@@ -423,6 +441,9 @@ impl Route {
         Ok(())
     }
 
+    /// Block until the route has fully stopped — either by `stop()` or by ending
+    /// on its own (a drained source under `exit_on_empty`, an exhausted stream).
+    /// Throws if the route ended on a permanent error.
     #[napi]
     pub fn join(&self) -> Result<()> {
         let handle = self.lock_run_state()?.join_handle.take();
@@ -430,6 +451,9 @@ impl Route {
             handle
                 .join()
                 .map_err(|_| Error::from_reason("Route background thread panicked"))?;
+        }
+        if let Some(failure) = self.lock_run_state()?.failure.take() {
+            return Err(Error::from_reason(failure));
         }
         Ok(())
     }
@@ -1060,6 +1084,44 @@ fn lock_active_route_names() -> Result<std::sync::MutexGuard<'static, HashSet<St
     active_route_names()
         .lock()
         .map_err(|_| Error::from_reason("Active route registry lock poisoned"))
+}
+
+/// Wait for an explicit `stop()` or for the route to end on its own — a drained
+/// source under `exit_on_empty`, an exhausted stream, or a permanent failure.
+///
+/// Returns the terminal outcome when the route ended by itself, `None` when a
+/// stop was requested. Without this a drain-then-exit route would leave `join()`
+/// waiting forever on a stop signal that never arrives.
+async fn wait_for_stop_or_end(
+    name: &str,
+    stop_rx: oneshot::Receiver<()>,
+) -> Option<core::RouteOutcome> {
+    tokio::pin!(stop_rx);
+    loop {
+        tokio::select! {
+            _ = &mut stop_rx => return None,
+            _ = tokio::time::sleep(ROUTE_END_POLL_INTERVAL) => {
+                if let Some(outcome) = core::route_outcome(name) {
+                    return Some(outcome);
+                }
+            }
+        }
+    }
+}
+
+/// Turn a self-terminated route's outcome into the result `join()` reports. A
+/// clean drain is success; a permanent failure carries the cause from the
+/// route's status.
+fn outcome_to_result(name: &str, outcome: Option<core::RouteOutcome>) -> Result<()> {
+    if outcome == Some(core::RouteOutcome::Failed) {
+        let cause = core::route_status(name)
+            .and_then(|status| status.error)
+            .unwrap_or_else(|| "permanent error".to_string());
+        return Err(Error::from_reason(format!(
+            "Route '{name}' failed: {cause}"
+        )));
+    }
+    Ok(())
 }
 
 fn finish_run(run_state: &Arc<Mutex<RouteRunState>>, name: &str) {

--- a/python/mq-bridge-py/Cargo.toml
+++ b/python/mq-bridge-py/Cargo.toml
@@ -25,9 +25,19 @@ schemars = "1.2"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml_ng.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "env-filter"] }
+
+# The extension module is dlopen'd by CPython, so mimalloc's thread-locals must
+# use the dynamic TLS model — the default initial-exec model draws from the fixed
+# static TLS surplus and fails to load on slim images ("cannot allocate memory in
+# static TLS block"). Not applicable on macOS/Windows.
+[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
+mimalloc = { version = "0.1", default-features = false, features = ["local_dynamic_tls"], optional = true }
+
+[target.'cfg(not(any(target_os = "linux", target_os = "freebsd")))'.dependencies]
+mimalloc = { version = "0.1", default-features = false, optional = true }
 
 # `auto-initialize` is only needed to embed the interpreter for the in-crate
 # `cargo test` unit tests (`Python::attach`). It must NOT be enabled for the
@@ -41,7 +51,12 @@ pyo3 = { version = "0.29.0", features = ["abi3-py38", "auto-initialize"] }
 default = ["full"]
 # Testing-only middleware hooks; do not include this feature in production wheels.
 middleware = ["mq-bridge/middleware"]
-full = ["mq-bridge/full", "rustls-aws-lc"]
+full = ["mq-bridge/full", "rustls-aws-lc", "mimalloc"]
+# mimalloc as Rust-side global allocator. Only redirects allocations made by
+# this cdylib's Rust code; CPython's own allocator is untouched. Safe here
+# because no raw Rust-allocated buffer crosses the extension boundary.
+# Excluded from `basic`, which also builds for musl.
+mimalloc = ["dep:mimalloc"]
 # All-platform set for the `mq-bridge-py-basic` wheel: the endpoints from
 # `mq-bridge/portable` that build across native OS targets without a special
 # toolchain, incl. musl/Alpine. amqp + aws pull aws-lc-sys (BoringSSL C), so

--- a/python/mq-bridge-py/mq_bridge/config.pyi
+++ b/python/mq-bridge-py/mq_bridge/config.pyi
@@ -113,7 +113,36 @@ class EncryptionConfig(TypedDict, total=False):
 
 class Endpoint(TypedDict, total=False):
     """Represents a connection point for messages, which can be a source (input) or a sink (output)."""
+    amqp: AmqpConfig
+    aws: AwsConfig
+    clickhouse: ClickHouseConfig
+    custom: Dict[str, Any]
+    fanout: List[Endpoint]
+    file: FileConfig
+    grpc: GrpcConfig
+    http: HttpConfig
+    ibmmq: IbmMqConfig
+    kafka: KafkaConfig
+    memory: MemoryConfig
     middlewares: List[Middleware]
+    mongodb: MongoDbConfig
+    mqtt: MqttConfig
+    nats: NatsConfig
+    null: Any
+    object_store: ObjectStoreConfig
+    postgres_cdc: PostgresCdcConfig
+    reader: Endpoint
+    redis_streams: RedisStreamsConfig
+    ref: str
+    request: RequestForwardConfig
+    response: ResponseConfig
+    sled: SledConfig
+    sqlx: SqlxConfig
+    static: StaticConfig
+    stream_buffer: StreamBufferConfig
+    switch: SwitchConfig
+    websocket: WebSocketConfig
+    zeromq: ZeroMqConfig
 
 
 class FileConfig(TypedDict, total=False):

--- a/python/mq-bridge-py/mq_bridge/config.pyi
+++ b/python/mq-bridge-py/mq_bridge/config.pyi
@@ -86,6 +86,7 @@ class DeadLetterQueueMiddleware(TypedDict, total=False):
 
 class DeduplicationMiddleware(TypedDict, total=False):
     """Deduplication middleware configuration."""
+    key: Optional[str]
     sled_path: Optional[str]
     store: Optional[str]
     ttl_seconds: Required[int]

--- a/python/mq-bridge-py/src/lib.rs
+++ b/python/mq-bridge-py/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
@@ -42,6 +46,8 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 const MAX_JSON_DEPTH: usize = 64;
+/// How often a blocking `run()`/`join()` checks whether the route ended on its own.
+const ROUTE_END_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 static PYTHON_HANDLER_CONCURRENCY: OnceLock<Option<Arc<Semaphore>>> = OnceLock::new();
 static ACTIVE_ROUTE_NAMES: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
@@ -54,6 +60,10 @@ struct RouteRunState {
     running: bool,
     stop_tx: Option<oneshot::Sender<()>>,
     join_handle: Option<thread::JoinHandle<()>>,
+    /// Set when a route started with `start()` ended on a permanent failure, so
+    /// `join()` can report the cause instead of returning as if it had stopped
+    /// cleanly. Taken by `join()`.
+    failure: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -542,9 +552,11 @@ impl Route {
         Ok(slf)
     }
 
-    /// Deploy the route and block the calling thread until `stop()` is called
-    /// (typically from another thread). Use `start()` instead if you want to
-    /// keep running Python code after the route is up.
+    /// Deploy the route and block the calling thread until it ends: either
+    /// `stop()` is called (typically from another thread) or the route finishes
+    /// on its own — a drained source under `exit_on_empty`, or an exhausted
+    /// stream. Raises if the route ended on a permanent error. Use `start()`
+    /// instead if you want to keep running Python code after the route is up.
     fn run(&self, py: Python<'_>) -> PyResult<()> {
         let route = self.lock_route()?.clone();
         let stop_rx = self.begin_run()?;
@@ -556,9 +568,10 @@ impl Route {
         py.detach(move || {
             let result = runtime.block_on(async move {
                 route.deploy(&deployed_name).await?;
-                let _ = stop_rx.await;
+                let outcome = wait_for_stop_or_end(&deployed_name, stop_rx).await;
+                let result = outcome_to_result(&deployed_name, outcome);
                 core::Route::stop(&deployed_name).await;
-                Ok::<(), anyhow::Error>(())
+                result
             });
             finish_run(&run_state, &name);
             result
@@ -596,10 +609,17 @@ impl Route {
             .name(format!("mqb-route-{name}"))
             .spawn(move || {
                 let stop_name = wait_name.clone();
-                runtime.block_on(async move {
-                    let _ = stop_rx.await;
+                let result = runtime.block_on(async move {
+                    let outcome = wait_for_stop_or_end(&stop_name, stop_rx).await;
+                    let result = outcome_to_result(&stop_name, outcome);
                     core::Route::stop(&stop_name).await;
+                    result
                 });
+                if let Err(err) = result {
+                    if let Ok(mut state) = wait_run_state.lock() {
+                        state.failure = Some(err.to_string());
+                    }
+                }
                 finish_run(&wait_run_state, &wait_name);
             }) {
             Ok(handle) => handle,
@@ -616,13 +636,18 @@ impl Route {
         Ok(())
     }
 
-    /// Block until a route started with `start()` has fully stopped. No-op for
-    /// routes that were never started or that ran via the blocking `run()`.
+    /// Block until a route started with `start()` has fully stopped — either by
+    /// `stop()` or by ending on its own (a drained source under `exit_on_empty`,
+    /// an exhausted stream). Raises if the route ended on a permanent error.
+    /// No-op for routes that were never started or that ran via `run()`.
     fn join(&self, py: Python<'_>) -> PyResult<()> {
         let handle = self.lock_run_state()?.join_handle.take();
         if let Some(handle) = handle {
             py.detach(|| handle.join())
                 .map_err(|_| PyRuntimeError::new_err("Route background thread panicked"))?;
+        }
+        if let Some(failure) = self.lock_run_state()?.failure.take() {
+            return Err(PyRuntimeError::new_err(failure));
         }
         Ok(())
     }
@@ -2014,6 +2039,42 @@ fn lock_active_route_names() -> PyResult<std::sync::MutexGuard<'static, HashSet<
     active_route_names()
         .lock()
         .map_err(|_| PyRuntimeError::new_err("Active route name lock poisoned"))
+}
+
+/// Wait for an explicit `stop()` or for the route to end on its own — a drained
+/// source under `exit_on_empty`, an exhausted stream, or a permanent failure.
+///
+/// Returns the terminal outcome when the route ended by itself, `None` when a
+/// stop was requested. Without this a drain-then-exit route would block its
+/// caller forever on a stop signal that never arrives.
+async fn wait_for_stop_or_end(
+    name: &str,
+    stop_rx: oneshot::Receiver<()>,
+) -> Option<core::RouteOutcome> {
+    tokio::pin!(stop_rx);
+    loop {
+        tokio::select! {
+            _ = &mut stop_rx => return None,
+            _ = tokio::time::sleep(ROUTE_END_POLL_INTERVAL) => {
+                if let Some(outcome) = core::route_outcome(name) {
+                    return Some(outcome);
+                }
+            }
+        }
+    }
+}
+
+/// Turn a self-terminated route's outcome into the result `run()`/`join()`
+/// reports. A clean drain is success; a permanent failure raises with the cause
+/// from the route's status.
+fn outcome_to_result(name: &str, outcome: Option<core::RouteOutcome>) -> anyhow::Result<()> {
+    if outcome == Some(core::RouteOutcome::Failed) {
+        let cause = core::route_status(name)
+            .and_then(|status| status.error)
+            .unwrap_or_else(|| "permanent error".to_string());
+        return Err(anyhow!("Route '{name}' failed: {cause}"));
+    }
+    Ok(())
 }
 
 /// Clear a route's running state and release its reserved name once it has

--- a/scripts/httparena/README.md
+++ b/scripts/httparena/README.md
@@ -50,7 +50,7 @@ profiles still run.
   reads its cert/key from `/certs/server.crt` + `/certs/server.key` (overridable
   via `TLS_CERT` / `TLS_KEY`) and is skipped when the certs are absent, so a local
   plaintext-only run still works. Uses the `ring` crypto provider.
-- **json-comp via response compression.** Setting `compression: gzip` (with a
+- **json-comp via response compression.** Setting `compression_enabled: true` (with a
   256-byte threshold) makes the server gzip bodies when the client advertises
   `Accept-Encoding: gzip`, identity otherwise — so the one `/json` handler serves
   both `json` and `json-comp`.

--- a/scripts/httparena/frameworks/mq-bridge-py/server.py
+++ b/scripts/httparena/frameworks/mq-bridge-py/server.py
@@ -23,7 +23,7 @@ static assets from ``/data/static`` (``STATIC_DIR``), Postgres from
 an empty result so the cleartext profiles still run.
 
 ``json-comp`` is handled by mq-bridge's response compression
-(``compression: gzip``): bodies over the threshold are gzip-encoded when the
+(``compression_enabled: true``): bodies over the threshold are gzip-encoded when the
 client advertises ``Accept-Encoding: gzip``, identity otherwise — so the same
 ``/json`` handler serves both ``json`` and ``json-comp``.
 """

--- a/scripts/httparena/frameworks/mq-bridge/src/main.rs
+++ b/scripts/httparena/frameworks/mq-bridge/src/main.rs
@@ -24,7 +24,7 @@
 //! `/async-db` then returns an empty result so the cleartext profiles still run.
 //!
 //! `json-comp` is handled by mq-bridge's response compression
-//! (`compression: gzip`): bodies above the threshold are gzip-encoded when the
+//! (`compression_enabled: true`): bodies above the threshold are gzip-encoded when the
 //! client advertises `Accept-Encoding: gzip`, and sent identity otherwise — so
 //! the same `/json` handler serves both the `json` and `json-comp` profiles.
 //!

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -393,12 +393,28 @@ pub async fn build_external_store(
 /// Cloud object-store checkpoint backend: one object per cursor key (no read-modify-write,
 /// no cross-process locking needed). URL/creds are resolved by `object_store` from env vars.
 #[cfg(feature = "object-store")]
-mod object_store_backend {
+pub(crate) mod object_store_backend {
     use super::{object_store_checkpoint_key, CheckpointStore};
     use anyhow::Context;
     use async_trait::async_trait;
     use object_store::{path::Path as ObjPath, ObjectStore, ObjectStoreExt};
     use std::sync::Arc;
+
+    /// Builds an `object_store` backend and its base prefix `Path` from a URL. Credentials and
+    /// backend options (`AWS_ACCESS_KEY_ID`, `AWS_ENDPOINT`, `AWS_REGION`, `AWS_ALLOW_HTTP`,
+    /// `GOOGLE_SERVICE_ACCOUNT`, ...) are read from the process environment.
+    ///
+    /// The backend config-key parsers only accept the lowercase form (`aws_access_key_id`), so
+    /// env-var names are lowercased before being folded into the builder — the same
+    /// normalization `AmazonS3Builder::from_env` does. Unrecognized keys are ignored. Bare
+    /// `parse_url` reads no env at all, which would fall through to the EC2/GCE metadata service.
+    pub(crate) fn build_store(url: &str) -> anyhow::Result<(Box<dyn ObjectStore>, ObjPath)> {
+        let parsed =
+            url::Url::parse(url).with_context(|| format!("Invalid object_store url '{url}'"))?;
+        let env = std::env::vars().map(|(k, v)| (k.to_ascii_lowercase(), v));
+        object_store::parse_url_opts(&parsed, env)
+            .with_context(|| format!("Failed to build object store for '{url}'"))
+    }
 
     struct ObjectStoreCheckpointStore {
         store: Arc<dyn ObjectStore>,
@@ -441,10 +457,7 @@ mod object_store_backend {
         source_name: &str,
         cursor_id: &str,
     ) -> anyhow::Result<Arc<dyn CheckpointStore>> {
-        let parsed = url::Url::parse(url)
-            .with_context(|| format!("Invalid object-store checkpoint URL '{url}'"))?;
-        let (store, base) = object_store::parse_url(&parsed)
-            .with_context(|| format!("Failed to build object store for '{url}'"))?;
+        let (store, base) = build_store(url)?;
         let key = object_store_checkpoint_key(source_name, cursor_id);
         let path = base.join(key);
         Ok(Arc::new(ObjectStoreCheckpointStore {

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -411,7 +411,13 @@ pub(crate) mod object_store_backend {
     pub(crate) fn build_store(url: &str) -> anyhow::Result<(Box<dyn ObjectStore>, ObjPath)> {
         let parsed =
             url::Url::parse(url).with_context(|| format!("Invalid object_store url '{url}'"))?;
-        let env = std::env::vars().map(|(k, v)| (k.to_ascii_lowercase(), v));
+        // `vars_os`, not `vars`: a single non-UTF-8 env var would panic the latter.
+        let env = std::env::vars_os().filter_map(|(k, v)| {
+            Some((
+                k.into_string().ok()?.to_ascii_lowercase(),
+                v.into_string().ok()?,
+            ))
+        });
         object_store::parse_url_opts(&parsed, env)
             .with_context(|| format!("Failed to build object store for '{url}'"))
     }

--- a/src/endpoints/clickhouse.rs
+++ b/src/endpoints/clickhouse.rs
@@ -607,7 +607,8 @@ impl MessageConsumer for ClickHouseCursorReader {
                 ConsumerError::Connection(anyhow!("Invalid JSONEachRow row: {}", e))
             })?;
             let cursor = extract_cursor(&row, &self.cursor_column).ok_or_else(|| {
-                ConsumerError::Connection(anyhow!(
+                // Schema-level, so re-polling fails identically: permanent, not a reconnect.
+                ConsumerError::Permanent(anyhow!(
                     "cursor_column '{}' missing or of unsupported type in result row",
                     self.cursor_column
                 ))

--- a/src/endpoints/clickhouse.rs
+++ b/src/endpoints/clickhouse.rs
@@ -639,8 +639,8 @@ impl MessageConsumer for ClickHouseCursorReader {
             if emit_len == 0 {
                 // The whole page shares one cursor value and more rows with that value exist beyond
                 // it. Advancing past the value would silently skip the remainder, so fail loudly
-                // instead of losing rows.
-                return Err(ConsumerError::Connection(anyhow!(
+                // instead of losing rows. Permanent: re-polling returns the same page forever.
+                return Err(ConsumerError::Permanent(anyhow!(
                     "cursor_column '{}' has a group of equal values larger than batch_size ({}); \
                      cannot page without skipping rows. Increase batch_size above the size of the \
                      largest equal-value group.",

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -2451,13 +2451,17 @@ pub(crate) fn parse_message(
                 {
                     match decode_byte_payload_record(buffer) {
                         Some(msg) => msg,
-                        None => CanonicalMessage {
-                            message_id: wrapper.message_id,
-                            payload: serde_json::to_vec(&wrapper.payload)
-                                .unwrap_or_default()
-                                .into(),
-                            metadata: wrapper.metadata,
-                        },
+                        None => {
+                            let mut metadata = wrapper.metadata;
+                            strip_byte_marker(&mut metadata);
+                            CanonicalMessage {
+                                message_id: wrapper.message_id,
+                                payload: serde_json::to_vec(&wrapper.payload)
+                                    .unwrap_or_default()
+                                    .into(),
+                                metadata,
+                            }
+                        }
                     }
                 }
                 Ok(wrapper) => CanonicalMessage {

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -1090,8 +1090,10 @@ fn compression_magic_name(head: &[u8]) -> Option<&'static str> {
 /// reading one with no `encryption` configured, which would otherwise emit
 /// ciphertext as messages under a clean success.
 fn looks_encrypted_at_rest(path: &str) -> bool {
+    use crate::support::crypto_envelope::{
+        CIPHER_AES_GCM, CIPHER_XCHACHA, ENVELOPE_VERSION, MIN_ENVELOPE_LEN,
+    };
     use std::io::Read;
-    const MIN_ENVELOPE: u64 = 3 + 1 + 12; // header + 1-byte key_id + shortest nonce
     let Ok(mut f) = std::fs::File::open(path) else {
         return false;
     };
@@ -1103,10 +1105,10 @@ fn looks_encrypted_at_rest(path: &str) -> bool {
         return false;
     }
     let frame_len = u64::from_be_bytes(head[..8].try_into().expect("8 bytes"));
-    frame_len >= MIN_ENVELOPE
+    frame_len >= MIN_ENVELOPE_LEN as u64
         && frame_len.saturating_add(8) <= file_len
-        && head[8] == 1
-        && head[9] <= 1
+        && head[8] == ENVELOPE_VERSION
+        && (head[9] == CIPHER_XCHACHA || head[9] == CIPHER_AES_GCM)
         && head[10] >= 1
 }
 

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -1691,13 +1691,53 @@ enum ConsumerBackend {
     Queue(FileQueueConsumer),
 }
 
+/// Probes a file source path. `Err` for a path that can never yield data;
+/// `Ok(Some(reason))` for one that is unopenable now but could still appear
+/// (missing file, missing parent directory, not yet readable).
+fn probe_source_path(path: &str) -> anyhow::Result<Option<String>> {
+    match std::fs::File::open(path) {
+        Ok(f) => {
+            // open(2) succeeds on a directory; only the read fails, and the reader
+            // threads report that as an ordinary end-of-file.
+            if f.metadata().map(|m| m.is_dir()).unwrap_or(false) {
+                anyhow::bail!("file source '{path}' is a directory, not a file");
+            }
+            Ok(None)
+        }
+        Err(e) => Ok(Some(format!("cannot open file source '{path}': {e}"))),
+    }
+}
+
 /// A consumer that reads messages from a file and removes them upon commit.
 pub struct FileConsumer {
     backend: ConsumerBackend,
+    path: String,
+    /// Why the source path could not be opened at construction, if it could not.
+    /// A live tail keeps waiting for the file to appear; a drain (`exit_on_empty`)
+    /// cannot, so it fails with this instead of blocking forever.
+    startup_open_error: Option<String>,
+    exit_on_empty: bool,
 }
 
 impl FileConsumer {
+    fn wrap(backend: ConsumerBackend) -> Self {
+        Self {
+            backend,
+            path: String::new(),
+            startup_open_error: None,
+            exit_on_empty: false,
+        }
+    }
+
     pub async fn new(config: &FileConfig) -> anyhow::Result<Self> {
+        let startup_open_error = probe_source_path(&config.path)?;
+        let mut consumer = Self::new_backend(config).await?;
+        consumer.path = config.path.clone();
+        consumer.startup_open_error = startup_open_error;
+        Ok(consumer)
+    }
+
+    async fn new_backend(config: &FileConfig) -> anyhow::Result<Self> {
         let delimiter = parse_delimiter(config.delimiter.as_deref())?;
         let format = config.format.clone();
         if matches!(format, FileFormat::Csv)
@@ -1785,18 +1825,16 @@ impl FileConsumer {
                 });
 
                 info!(path = %config.path, mode = "queue (delete, optimized)", "File consumer connected");
-                Ok(Self {
-                    backend: ConsumerBackend::Queue(FileQueueConsumer {
-                        msg_rx,
-                        lines_in_memory,
-                        path: config.path.clone(),
-                        file_lock,
-                        buffer: Arc::new(Mutex::new(Vec::new())),
-                        delimiter,
-                        ready,
-                        pending_eof: false,
-                    }),
-                })
+                Ok(Self::wrap(ConsumerBackend::Queue(FileQueueConsumer {
+                    msg_rx,
+                    lines_in_memory,
+                    path: config.path.clone(),
+                    file_lock,
+                    buffer: Arc::new(Mutex::new(Vec::new())),
+                    delimiter,
+                    ready,
+                    pending_eof: false,
+                })))
             }
             Some(FileConsumerMode::Subscribe { delete: true }) => {
                 let key = format!(
@@ -1827,9 +1865,9 @@ impl FileConsumer {
                 let subscriber_id = format!("file-sub-{}", fast_uuid_v7::gen_id_str());
                 info!(path = %config.path, mode = "subscribe (delete)", subscriber_id = %subscriber_id, "File consumer connected");
 
-                Ok(Self {
-                    backend: ConsumerBackend::EventStore(store.consumer(subscriber_id)),
-                })
+                Ok(Self::wrap(ConsumerBackend::EventStore(
+                    store.consumer(subscriber_id),
+                )))
             }
         }
     }
@@ -1889,19 +1927,17 @@ impl FileConsumer {
             );
         });
         info!(path = %config.path, mode = "member consume (compressed/encrypted)", "File consumer connected");
-        Ok(Self {
-            backend: ConsumerBackend::Tail(FileTailConsumer {
-                msg_rx,
-                buffer: Vec::new(),
-                offset_file: None,
-                ready,
-                pending_eof: false,
-                decode_error: Some(decode_error),
-                // Member (compressed/encrypted) readers decode framed members, not
-                // delimiter-split lines, so the trailing-partial-line rule doesn't apply.
-                drain_on_empty: Arc::new(AtomicBool::new(false)),
-            }),
-        })
+        Ok(Self::wrap(ConsumerBackend::Tail(FileTailConsumer {
+            msg_rx,
+            buffer: Vec::new(),
+            offset_file: None,
+            ready,
+            pending_eof: false,
+            decode_error: Some(decode_error),
+            // Member (compressed/encrypted) readers decode framed members, not
+            // delimiter-split lines, so the trailing-partial-line rule doesn't apply.
+            drain_on_empty: Arc::new(AtomicBool::new(false)),
+        })))
     }
 
     async fn new_tail(
@@ -1962,17 +1998,15 @@ impl FileConsumer {
 
         info!(path = %path, mode = "tail (no-delete, optimized)", "File consumer connected");
 
-        Ok(Self {
-            backend: ConsumerBackend::Tail(FileTailConsumer {
-                msg_rx,
-                buffer: Vec::new(),
-                offset_file,
-                ready,
-                pending_eof: false,
-                decode_error: None,
-                drain_on_empty,
-            }),
-        })
+        Ok(Self::wrap(ConsumerBackend::Tail(FileTailConsumer {
+            msg_rx,
+            buffer: Vec::new(),
+            offset_file,
+            ready,
+            pending_eof: false,
+            decode_error: None,
+            drain_on_empty,
+        })))
     }
 
     /// Returns true if the consumer is ready to receive messages.
@@ -1988,6 +2022,7 @@ impl FileConsumer {
 #[async_trait]
 impl MessageConsumer for FileConsumer {
     fn set_exit_on_empty(&mut self, exit_on_empty: bool) {
+        self.exit_on_empty = exit_on_empty;
         match &mut self.backend {
             // Only the delimiter-splitting tail reader distinguishes a complete final
             // record from a torn mid-write; propagate the drain intent to its thread.
@@ -2002,6 +2037,17 @@ impl MessageConsumer for FileConsumer {
     // a cumulative byte offset (the max acked `file_offset`), so out-of-order
     // commits could advance the offset past un-acked messages and lose them.
     async fn receive_batch(&mut self, max_messages: usize) -> Result<ReceivedBatch, ConsumerError> {
+        // The path was unopenable at startup. A live tail waits for it (rotation,
+        // a writer that hasn't created it yet), but a drain has nothing to wait
+        // for, so re-probe and fail rather than block forever on a typo'd path.
+        if self.exit_on_empty && self.startup_open_error.is_some() {
+            match probe_source_path(&self.path) {
+                Ok(None) => self.startup_open_error = None,
+                Ok(Some(reason)) => return Err(ConsumerError::Permanent(anyhow::anyhow!(reason))),
+                Err(e) => return Err(ConsumerError::Permanent(e)),
+            }
+        }
+
         match &mut self.backend {
             ConsumerBackend::EventStore(c) => c.receive_batch(max_messages).await,
             ConsumerBackend::Tail(c) => {

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -1068,7 +1068,11 @@ fn sniff_compression_magic(path: &str) -> Option<&'static str> {
     let mut head = [0u8; 4];
     let mut f = std::fs::File::open(path).ok()?;
     let n = f.read(&mut head).ok()?;
-    let head = &head[..n];
+    compression_magic_name(&head[..n])
+}
+
+/// The `compression` codec name whose magic bytes `head` begins with, if any.
+fn compression_magic_name(head: &[u8]) -> Option<&'static str> {
     if head.starts_with(&[0x1f, 0x8b]) {
         Some("gzip")
     } else if head.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]) {
@@ -1078,6 +1082,32 @@ fn sniff_compression_magic(path: &str) -> Option<&'static str> {
     } else {
         None
     }
+}
+
+/// Whether the file at `path` looks like an at-rest encrypted file: an 8-byte
+/// big-endian frame length that fits the file, followed by a well-formed crypto
+/// envelope header (`[version=1][cipher 0|1][key_id_len>=1]`). Used to reject
+/// reading one with no `encryption` configured, which would otherwise emit
+/// ciphertext as messages under a clean success.
+fn looks_encrypted_at_rest(path: &str) -> bool {
+    use std::io::Read;
+    const MIN_ENVELOPE: u64 = 3 + 1 + 12; // header + 1-byte key_id + shortest nonce
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return false;
+    };
+    let Ok(file_len) = f.metadata().map(|m| m.len()) else {
+        return false;
+    };
+    let mut head = [0u8; 11];
+    if f.read_exact(&mut head).is_err() {
+        return false;
+    }
+    let frame_len = u64::from_be_bytes(head[..8].try_into().expect("8 bytes"));
+    frame_len >= MIN_ENVELOPE
+        && frame_len.saturating_add(8) <= file_len
+        && head[8] == 1
+        && head[9] <= 1
+        && head[10] >= 1
 }
 
 fn read_until_bytes_sync<R: std::io::BufRead>(
@@ -1665,6 +1695,19 @@ impl<R: std::io::Read> EncryptedFramesReader<R> {
         } else {
             member
         };
+        // Decryption succeeds regardless of the inner codec, so an unconfigured
+        // compression would otherwise be emitted as one binary "message".
+        if self.compression == Compression::None {
+            if let Some(codec) = compression_magic_name(&member) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "decrypted data begins with a {codec} magic header but no `compression` \
+                         is configured; set `compression: {codec}`"
+                    ),
+                ));
+            }
+        }
         self.current = std::io::Cursor::new(member);
         Ok(true)
     }
@@ -1774,6 +1817,15 @@ impl FileConsumer {
             return Err(anyhow::anyhow!(
                 "file '{}' begins with a {codec} magic header but no `compression` is configured; \
                  set `compression: {codec}` (and any `encryption`) to match how it was written",
+                config.path
+            ));
+        }
+        // Same guard for encryption: the envelope is behind an 8-byte frame prefix,
+        // so a compressor magic never shows up at offset 0 for an encrypted file.
+        if looks_encrypted_at_rest(&config.path) {
+            return Err(anyhow::anyhow!(
+                "file '{}' looks encrypted but no `encryption` is configured; \
+                 set `encryption` (and any `compression`) to match how it was written",
                 config.path
             ));
         }

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -1738,15 +1738,14 @@ enum ConsumerBackend {
 /// `Ok(Some(reason))` for one that is unopenable now but could still appear
 /// (missing file, missing parent directory, not yet readable).
 fn probe_source_path(path: &str) -> anyhow::Result<Option<String>> {
+    // Checked before opening: Windows refuses to open a directory at all, while
+    // on Unix the open succeeds and only the read fails, which the reader threads
+    // report as an ordinary end-of-file.
+    if std::fs::metadata(path).map(|m| m.is_dir()).unwrap_or(false) {
+        anyhow::bail!("file source '{path}' is a directory, not a file");
+    }
     match std::fs::File::open(path) {
-        Ok(f) => {
-            // open(2) succeeds on a directory; only the read fails, and the reader
-            // threads report that as an ordinary end-of-file.
-            if f.metadata().map(|m| m.is_dir()).unwrap_or(false) {
-                anyhow::bail!("file source '{path}' is a directory, not a file");
-            }
-            Ok(None)
-        }
+        Ok(_) => Ok(None),
         Err(e) => Ok(Some(format!("cannot open file source '{path}': {e}"))),
     }
 }

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -2346,7 +2346,7 @@ pub(crate) fn encode_record(
                     metadata: &msg.metadata,
                 })
             } else {
-                serde_json::to_vec(msg)
+                encode_byte_payload(msg)
             }
         }
         FileFormat::Text => {
@@ -2357,11 +2357,31 @@ pub(crate) fn encode_record(
                     metadata: &msg.metadata,
                 })
             } else {
-                serde_json::to_vec(msg)
+                encode_byte_payload(msg)
             }
         }
         FileFormat::Csv => unreachable!("CSV is encoded by the caller, not encode_record"),
     }
+}
+
+/// Marks a record whose payload is neither JSON nor UTF-8 and was therefore written as a
+/// byte array. Without it a `json` reader hands the next hop the *textual* array
+/// `[40,181,47,…]`, which breaks any binary payload (compression, encryption).
+pub(crate) const BYTE_PAYLOAD_KEY: &str = "mq_bridge.payload_bytes";
+/// The only value this crate writes for [`BYTE_PAYLOAD_KEY`]. A reader honours the marker
+/// only at this exact value, so an unrelated key of the same name cannot redirect decoding.
+const BYTE_PAYLOAD_MARK: &str = "1";
+
+/// Write a binary payload under a `json`/`text` sink as the byte-array wrapper, marked so
+/// the reader restores the bytes instead of the array's JSON text.
+fn encode_byte_payload(msg: &CanonicalMessage) -> Result<Vec<u8>, serde_json::Error> {
+    let mut metadata = msg.metadata.clone();
+    metadata.insert(BYTE_PAYLOAD_KEY.to_string(), BYTE_PAYLOAD_MARK.to_string());
+    serde_json::to_vec(&RecordWrapper {
+        message_id: msg.message_id,
+        payload: &msg.payload,
+        metadata: &metadata,
+    })
 }
 
 /// Parses one file line into a message. Returns `None` for CSV header lines,
@@ -2419,6 +2439,25 @@ pub(crate) fn parse_message(
             }
 
             let msg = match serde_json::from_slice::<AnyPayloadMessage>(buffer) {
+                // A marked record holds a byte array the sink could not represent as JSON;
+                // re-read it as bytes so a binary payload survives the round trip. The
+                // payload must really be an array — a marked string or object is not ours.
+                Ok(wrapper)
+                    if wrapper.metadata.get(BYTE_PAYLOAD_KEY).map(String::as_str)
+                        == Some(BYTE_PAYLOAD_MARK)
+                        && wrapper.payload.is_array() =>
+                {
+                    match decode_byte_payload_record(buffer) {
+                        Some(msg) => msg,
+                        None => CanonicalMessage {
+                            message_id: wrapper.message_id,
+                            payload: serde_json::to_vec(&wrapper.payload)
+                                .unwrap_or_default()
+                                .into(),
+                            metadata: wrapper.metadata,
+                        },
+                    }
+                }
                 Ok(wrapper) => CanonicalMessage {
                     message_id: wrapper.message_id,
                     payload: serde_json::to_vec(&wrapper.payload)
@@ -2433,25 +2472,48 @@ pub(crate) fn parse_message(
         // `normal` and `text` want the payload as bytes, so it is decoded in one
         // pass by [`RawPayload`] rather than through a `serde_json::Value`.
         FileFormat::Normal | FileFormat::Text => {
-            #[derive(serde::Deserialize)]
-            struct BytePayloadMessage {
-                #[serde(deserialize_with = "deserialize_u128")]
-                message_id: u128,
-                payload: RawPayload,
-                #[serde(default)]
-                metadata: HashMap<String, String>,
-            }
-
             let msg = match serde_json::from_slice::<BytePayloadMessage>(buffer) {
-                Ok(wrapper) => CanonicalMessage {
-                    message_id: wrapper.message_id,
-                    payload: wrapper.payload.into_bytes().into(),
-                    metadata: wrapper.metadata,
-                },
+                Ok(mut wrapper) => {
+                    strip_byte_marker(&mut wrapper.metadata);
+                    CanonicalMessage {
+                        message_id: wrapper.message_id,
+                        payload: wrapper.payload.into_bytes().into(),
+                        metadata: wrapper.metadata,
+                    }
+                }
                 Err(e) => raw_fallback_message(buffer, e),
             };
             Some(msg)
         }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct BytePayloadMessage {
+    #[serde(deserialize_with = "deserialize_u128")]
+    message_id: u128,
+    payload: RawPayload,
+    #[serde(default)]
+    metadata: HashMap<String, String>,
+}
+
+/// Decode a record whose `payload` is wanted as bytes, in one pass via [`RawPayload`]
+/// rather than through a `serde_json::Value`. `None` if the line is not that envelope.
+fn decode_byte_payload_record(buffer: &[u8]) -> Option<CanonicalMessage> {
+    let mut wrapper = serde_json::from_slice::<BytePayloadMessage>(buffer).ok()?;
+    strip_byte_marker(&mut wrapper.metadata);
+    Some(CanonicalMessage {
+        message_id: wrapper.message_id,
+        payload: wrapper.payload.into_bytes().into(),
+        metadata: wrapper.metadata,
+    })
+}
+
+/// Drop the marker this crate wrote — it is a storage detail, not the message's own
+/// metadata. Any other value under that key belongs to the producer and is left alone.
+fn strip_byte_marker(metadata: &mut HashMap<String, String>) {
+    if metadata.get(BYTE_PAYLOAD_KEY).map(String::as_str) == Some(BYTE_PAYLOAD_MARK) {
+        metadata.remove(BYTE_PAYLOAD_KEY);
     }
 }
 

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -728,7 +728,7 @@ impl MessagePublisher for FilePublisher {
                         csv_header_guard.as_mut(),
                     )
                     .await;
-                    return Err(PublisherError::NonRetryable(anyhow::anyhow!(e)));
+                    return Err(PublisherError::Retryable(anyhow::anyhow!(e)));
                 }
             }
             let serialized_msg = match serialized_msg {

--- a/src/endpoints/file/tests.rs
+++ b/src/endpoints/file/tests.rs
@@ -1764,3 +1764,97 @@ async fn test_file_tail_live_withholds_final_line_without_newline() {
         "live tail withholds the final record until its delimiter arrives"
     );
 }
+
+/// A source path that cannot be opened must end a drain with a permanent error,
+/// not block forever (missing file, missing parent directory, unreadable file).
+#[tokio::test]
+async fn drain_fails_on_unopenable_source_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let unreadable = dir.path().join("locked.jsonl");
+    std::fs::write(&unreadable, b"{\"a\":1}\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+    }
+
+    let mut paths = vec![
+        dir.path().join("missing.jsonl").display().to_string(),
+        dir.path()
+            .join("no-such-dir/in.jsonl")
+            .display()
+            .to_string(),
+    ];
+    // A mode-000 file is still readable by root; only assert on it where the
+    // permission actually bites.
+    if std::fs::File::open(&unreadable).is_err() {
+        paths.push(unreadable.display().to_string());
+    }
+
+    for path in paths {
+        let mut source = FileConsumer::new(&FileConfig {
+            path: path.clone(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_or_else(|e| panic!("construction should succeed for {path}: {e}"));
+        source.set_exit_on_empty(true);
+
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(2), source.receive_batch(16))
+                .await
+                .unwrap_or_else(|_| panic!("receive_batch hung on {path}"));
+
+        match result {
+            Err(crate::errors::ConsumerError::Permanent(e)) => {
+                assert!(
+                    e.to_string().contains(&path),
+                    "error should name the path: {e}"
+                );
+            }
+            other => panic!("expected a permanent error for {path}, got {other:?}"),
+        }
+    }
+}
+
+/// A directory given as a file source is permanent nonsense: reject it at
+/// construction rather than reporting a clean, empty drain.
+#[tokio::test]
+async fn directory_as_source_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let err = match FileConsumer::new(&FileConfig {
+        path: dir.path().display().to_string(),
+        ..Default::default()
+    })
+    .await
+    {
+        Ok(_) => panic!("a directory is not a readable file source"),
+        Err(e) => e,
+    };
+    assert!(err.to_string().contains("is a directory"), "got: {err}");
+}
+
+/// A live tail (no drain) still waits for a file that does not exist yet.
+#[tokio::test]
+async fn live_tail_waits_for_a_missing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("later.jsonl");
+    let mut source = FileConsumer::new(&FileConfig {
+        path: path.display().to_string(),
+        ..Default::default()
+    })
+    .await
+    .unwrap();
+
+    let writer = path.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        std::fs::write(&writer, b"{\"a\":1}\n").unwrap();
+    });
+
+    let batch = tokio::time::timeout(std::time::Duration::from_secs(5), source.receive_batch(16))
+        .await
+        .expect("live tail should pick the file up once it appears")
+        .expect("receive_batch errored");
+    assert_eq!(batch.messages.len(), 1);
+}

--- a/src/endpoints/file/tests.rs
+++ b/src/endpoints/file/tests.rs
@@ -1927,7 +1927,11 @@ mod at_rest_codec_mismatch {
 
         let mut last = None;
         for _ in 0..20 {
-            match source.receive_batch(16).await {
+            let received =
+                tokio::time::timeout(std::time::Duration::from_secs(10), source.receive_batch(16))
+                    .await
+                    .expect("receive_batch timed out");
+            match received {
                 Err(crate::errors::ConsumerError::Permanent(e)) => {
                     last = Some(e.to_string());
                     break;
@@ -1959,7 +1963,11 @@ mod at_rest_codec_mismatch {
         .await
         .unwrap();
         source.set_exit_on_empty(true);
-        let batch = source.receive_batch(16).await.unwrap();
+        let batch =
+            tokio::time::timeout(std::time::Duration::from_secs(10), source.receive_batch(16))
+                .await
+                .expect("receive_batch timed out")
+                .unwrap();
         assert_eq!(batch.messages.len(), 2);
     }
 }

--- a/src/endpoints/file/tests.rs
+++ b/src/endpoints/file/tests.rs
@@ -1858,3 +1858,108 @@ async fn live_tail_waits_for_a_missing_file() {
         .expect("receive_batch errored");
     assert_eq!(batch.messages.len(), 1);
 }
+
+#[cfg(all(feature = "encryption", feature = "compression"))]
+mod at_rest_codec_mismatch {
+    use super::*;
+    use crate::models::EncryptionConfig;
+
+    const KEY: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    fn encryption() -> Option<EncryptionConfig> {
+        Some(EncryptionConfig {
+            key: KEY.to_string(),
+            ..Default::default()
+        })
+    }
+
+    async fn write_encrypted(path: &str, compression: Compression) {
+        let publisher = FilePublisher::new(&FileConfig {
+            path: path.to_string(),
+            compression,
+            encryption: encryption(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        publisher
+            .send_batch(vec![msg!(json!({"a": 1})), msg!(json!({"a": 2}))])
+            .await
+            .unwrap();
+    }
+
+    /// An encrypted file read with no `encryption` configured used to emit its
+    /// ciphertext as messages under a clean success.
+    #[tokio::test]
+    async fn encrypted_source_without_encryption_is_rejected() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("enc.jsonl").display().to_string();
+        write_encrypted(&path, Compression::Gzip).await;
+
+        let err = match FileConsumer::new(&FileConfig {
+            path: path.clone(),
+            ..Default::default()
+        })
+        .await
+        {
+            Ok(_) => panic!("an encrypted file must not be read as plaintext"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("looks encrypted"), "got: {err}");
+    }
+
+    /// Decryption succeeds whatever the inner codec is, so a missing
+    /// `compression` used to surface the compressed bytes as one message.
+    #[tokio::test]
+    async fn decrypted_compression_mismatch_is_permanent() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("enc-gzip.jsonl").display().to_string();
+        write_encrypted(&path, Compression::Gzip).await;
+
+        let mut source = FileConsumer::new(&FileConfig {
+            path: path.clone(),
+            encryption: encryption(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        source.set_exit_on_empty(true);
+
+        let mut last = None;
+        for _ in 0..20 {
+            match source.receive_batch(16).await {
+                Err(crate::errors::ConsumerError::Permanent(e)) => {
+                    last = Some(e.to_string());
+                    break;
+                }
+                Ok(batch) => assert!(
+                    batch.messages.is_empty(),
+                    "gzip bytes must not be emitted as messages"
+                ),
+                Err(e) => panic!("unexpected error: {e:?}"),
+            }
+        }
+        let err = last.expect("expected a permanent decode error");
+        assert!(err.contains("Giving up decoding"), "got: {err}");
+    }
+
+    /// The matching configuration still round-trips.
+    #[tokio::test]
+    async fn encrypted_and_compressed_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("ok.jsonl").display().to_string();
+        write_encrypted(&path, Compression::Gzip).await;
+
+        let mut source = FileConsumer::new(&FileConfig {
+            path: path.clone(),
+            compression: Compression::Gzip,
+            encryption: encryption(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        source.set_exit_on_empty(true);
+        let batch = source.receive_batch(16).await.unwrap();
+        assert_eq!(batch.messages.len(), 2);
+    }
+}

--- a/src/endpoints/file/tests.rs
+++ b/src/endpoints/file/tests.rs
@@ -1963,3 +1963,71 @@ mod at_rest_codec_mismatch {
         assert_eq!(batch.messages.len(), 2);
     }
 }
+
+/// A payload that is neither JSON nor UTF-8 — what the `compression` and `encryption`
+/// middlewares produce — must survive a `json`/`text` sink. It used to come back as the
+/// *textual* byte array `[40,181,47,…]`, so the reader's first byte was `[` (91).
+#[test]
+fn binary_payload_round_trips_through_json_and_text_formats() {
+    use crate::endpoints::file::{encode_record, parse_message};
+
+    let payload = vec![0x28u8, 0xb5, 0x2f, 0xfd, 0x00, 0xff, 0xfe];
+    let msg = crate::CanonicalMessage::new(payload.clone(), Some(7));
+
+    for format in [FileFormat::Json, FileFormat::Text] {
+        let line = encode_record(&msg, &format).unwrap();
+        let parsed = parse_message(&line, &format, &mut None).expect("record must parse");
+        assert_eq!(
+            parsed.payload.as_ref(),
+            payload.as_slice(),
+            "{format:?} must preserve a binary payload verbatim"
+        );
+        assert!(
+            !parsed.metadata.contains_key("mq_bridge.payload_bytes"),
+            "the byte marker is a storage detail and must not leak downstream"
+        );
+    }
+}
+
+/// The marker is honoured only at the value this crate writes, and only when the payload
+/// really is a byte array — a producer's own key of that name must not redirect decoding.
+#[test]
+fn byte_payload_marker_is_only_honoured_when_it_is_ours() {
+    use crate::endpoints::file::parse_message;
+
+    // A marked *string* payload is not ours: it stays the JSON text it was.
+    let line =
+        br#"{"message_id":"1","payload":"hello","metadata":{"mq_bridge.payload_bytes":"1"}}"#;
+    let parsed = parse_message(line, &FileFormat::Json, &mut None).unwrap();
+    assert_eq!(parsed.payload.as_ref(), br#""hello""#);
+
+    // A foreign value under the same key is the producer's data and survives untouched.
+    let line =
+        br#"{"message_id":"2","payload":[1,2,3],"metadata":{"mq_bridge.payload_bytes":"theirs"}}"#;
+    let parsed = parse_message(line, &FileFormat::Json, &mut None).unwrap();
+    assert_eq!(parsed.payload.as_ref(), b"[1,2,3]");
+    assert_eq!(
+        parsed
+            .metadata
+            .get("mq_bridge.payload_bytes")
+            .map(String::as_str),
+        Some("theirs")
+    );
+}
+
+/// A binary payload still round-trips when the message already carries the reserved key.
+/// `mq_bridge.*` is the crate's namespace — as with `mq_bridge.dlq.*` and
+/// `mq_bridge.retry.attempt`, a value a producer puts there is ours to overwrite.
+#[test]
+fn pre_existing_marker_does_not_break_a_binary_round_trip() {
+    use crate::endpoints::file::{encode_record, parse_message};
+
+    let payload = vec![0x28u8, 0xb5, 0x2f, 0xfd, 0x00];
+    let mut msg = crate::CanonicalMessage::new(payload.clone(), Some(9));
+    msg.metadata
+        .insert("mq_bridge.payload_bytes".to_string(), "theirs".to_string());
+
+    let line = encode_record(&msg, &FileFormat::Json).unwrap();
+    let parsed = parse_message(&line, &FileFormat::Json, &mut None).unwrap();
+    assert_eq!(parsed.payload.as_ref(), payload.as_slice());
+}

--- a/src/endpoints/http/publisher.rs
+++ b/src/endpoints/http/publisher.rs
@@ -11,6 +11,28 @@ type HttpClient = hyper_util::client::legacy::Client<
     http_body_util::Full<Bytes>,
 >;
 
+/// Cap on how much of a failed response body is quoted in the error. Bodies may be up to
+/// [`MAX_HTTP_BODY_BYTES`]; an error string carried through retries and logs must not be.
+const MAX_ERROR_BODY_EXCERPT_BYTES: usize = 2048;
+
+/// Renders the leading bytes of a response body for an error message, truncating on a UTF-8
+/// character boundary so a multi-byte character is never split.
+fn error_body_excerpt(body: &[u8]) -> String {
+    if body.len() <= MAX_ERROR_BODY_EXCERPT_BYTES {
+        return String::from_utf8_lossy(body).into_owned();
+    }
+    // Back off any UTF-8 continuation bytes (0b10xxxxxx) so the cut lands between characters.
+    let mut end = MAX_ERROR_BODY_EXCERPT_BYTES;
+    while end > 0 && body[end] & 0b1100_0000 == 0b1000_0000 {
+        end -= 1;
+    }
+    format!(
+        "{}... ({} bytes truncated)",
+        String::from_utf8_lossy(&body[..end]),
+        body.len() - end
+    )
+}
+
 /// Builds a connection-pooling hyper client for the given TLS/connector settings.
 fn build_http_client(config: &HttpConfig) -> anyhow::Result<HttpClient> {
     let tls_client_config = create_rustls_client_config(&config.tls)
@@ -406,7 +428,7 @@ impl HttpPublisher {
             let error = anyhow::anyhow!(
                 "HTTP send request failed with status {}: {:?}",
                 response_status,
-                String::from_utf8_lossy(&response_bytes)
+                error_body_excerpt(&response_bytes)
             );
 
             if response_status.is_client_error() {

--- a/src/endpoints/http/stream.rs
+++ b/src/endpoints/http/stream.rs
@@ -524,6 +524,7 @@ async fn send_stream_item(
 
     let response_tx = dispatch.response_tx.clone();
     let response_format = dispatch.response_format;
+    let send_timeout = std::time::Duration::from_millis(2000).min(dispatch.request_timeout / 2);
     if let Some(inline_publisher) = dispatch.inline_publisher.as_ref() {
         let disposition =
             match tokio::time::timeout(dispatch.request_timeout, inline_publisher.send(message))
@@ -537,14 +538,13 @@ async fn send_stream_item(
                 Err(_) => return Err(anyhow!("HTTP inline stream publisher timed out")),
             };
 
-        return streamable_commit(disposition, response_tx, response_format).await;
+        return streamable_commit(disposition, response_tx, response_format, send_timeout).await;
     }
 
     let commit = Box::new(move |disposition: MessageDisposition| {
-        streamable_commit(disposition, response_tx, response_format)
+        streamable_commit(disposition, response_tx, response_format, send_timeout)
     });
 
-    let send_timeout = std::time::Duration::from_millis(2000).min(dispatch.request_timeout / 2);
     match tokio::time::timeout(send_timeout, dispatch.tx.send((message, commit))).await {
         Ok(Ok(_)) => Ok(()),
         Ok(Err(error)) => Err(anyhow!("Internal pipeline closed: {}", error)),
@@ -556,6 +556,7 @@ fn streamable_commit(
     disposition: MessageDisposition,
     response_tx: Option<HttpStreamResponseTx>,
     response_format: HttpStreamFormat,
+    send_timeout: std::time::Duration,
 ) -> BoxFuture<'static, anyhow::Result<()>> {
     Box::pin(async move {
         let Some(response_tx) = response_tx else {
@@ -573,8 +574,11 @@ fn streamable_commit(
             )),
         };
 
-        if response_tx.send(Ok(frame)).await.is_err() {
-            debug!("HTTP stream closed before response was sent");
+        // A stalled reader must not pin this commit forever; a timeout is treated as a
+        // closed stream.
+        match tokio::time::timeout(send_timeout, response_tx.send(Ok(frame))).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) | Err(_) => debug!("HTTP stream closed before response was sent"),
         }
         Ok(())
     })

--- a/src/endpoints/memory/framed.rs
+++ b/src/endpoints/memory/framed.rs
@@ -324,7 +324,7 @@ mod tests {
 
         // A payload whose leading bytes would themselves read as a plausible length
         // prefix if mistaken for the start of a frame.
-        let messages = vec![CanonicalMessage::from_vec(&[0u8; 64])];
+        let messages = vec![CanonicalMessage::from_vec([0u8; 64])];
         let encoded = rmp_serde::to_vec(&messages).unwrap();
 
         {

--- a/src/endpoints/memory/framed.rs
+++ b/src/endpoints/memory/framed.rs
@@ -39,17 +39,30 @@ const LENGTH_PREFIX_BYTES: usize = 4;
 const STALLED_SEND_WARN_AFTER: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// An IO handle wrapped in the length-delimited codec.
-pub(crate) type FramedIo<S> = Framed<S, LengthDelimitedCodec>;
+///
+/// `maybe_partial` shadows the codec's private decode state. `LengthDelimitedCodec`
+/// consumes the length prefix as soon as it has read one, so while it is mid-frame the
+/// read buffer starts at payload bytes rather than at a prefix — which [`buffered_frames`]
+/// cannot tell apart from a frame boundary. The flag is set pessimistically before every
+/// read and cleared only once a frame has been decoded (which leaves the codec back at a
+/// boundary), so a cancelled read stays pessimistic.
+pub(crate) struct FramedIo<S> {
+    inner: Framed<S, LengthDelimitedCodec>,
+    maybe_partial: bool,
+}
 
 /// Wrap an IO handle in the codec used by every IPC transport.
 pub(crate) fn wrap<S>(io: S) -> FramedIo<S>
 where
     S: AsyncRead + AsyncWrite,
 {
-    LengthDelimitedCodec::builder()
-        .length_field_type::<u32>()
-        .max_frame_length(MAX_FRAME_BYTES)
-        .new_framed(io)
+    FramedIo {
+        inner: LengthDelimitedCodec::builder()
+            .length_field_type::<u32>()
+            .max_frame_length(MAX_FRAME_BYTES)
+            .new_framed(io),
+        maybe_partial: false,
+    }
 }
 
 /// Encode and send a batch as a single frame. Returns the encoded byte count.
@@ -74,7 +87,7 @@ where
     }
     let len = data.len();
 
-    let mut send = std::pin::pin!(framed.send(Bytes::from(data)));
+    let mut send = std::pin::pin!(framed.inner.send(Bytes::from(data)));
     tokio::select! {
         result = &mut send => result?,
         _ = tokio::time::sleep(STALLED_SEND_WARN_AFTER) => {
@@ -102,8 +115,13 @@ pub(crate) async fn recv_batch<S>(framed: &mut FramedIo<S>) -> Result<Vec<Canoni
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
-    match framed.next().await {
-        Some(frame) => decode(&frame?),
+    framed.maybe_partial = true;
+    match framed.inner.next().await {
+        Some(frame) => {
+            let frame = frame?;
+            framed.maybe_partial = false;
+            decode(&frame)
+        }
         // Clean EOF. Surfaced as an io error so callers' disconnect detection
         // treats it like any other peer drop.
         None => Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof).into()),
@@ -118,8 +136,13 @@ pub(crate) fn try_recv_batch<S>(framed: &mut FramedIo<S>) -> Result<Option<Vec<C
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
-    match framed.next().now_or_never() {
-        Some(Some(frame)) => decode(&frame?).map(Some),
+    framed.maybe_partial = true;
+    match framed.inner.next().now_or_never() {
+        Some(Some(frame)) => {
+            let frame = frame?;
+            framed.maybe_partial = false;
+            decode(&frame).map(Some)
+        }
         Some(None) => Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof).into()),
         None => Ok(None),
     }
@@ -129,8 +152,14 @@ where
 ///
 /// These are decodable without touching the socket. Walks the length prefixes
 /// without decoding payloads.
+///
+/// A lower bound: while the codec may be mid-frame the buffer does not start at a length
+/// prefix, so nothing can be counted and this reports 0.
 pub(crate) fn buffered_frames<S>(framed: &FramedIo<S>) -> usize {
-    let buf: &BytesMut = framed.read_buffer();
+    if framed.maybe_partial {
+        return 0;
+    }
+    let buf: &BytesMut = framed.inner.read_buffer();
     let mut offset = 0usize;
     let mut frames = 0usize;
 
@@ -238,7 +267,7 @@ mod tests {
         // Write the length prefix and a slice of the payload, then stop.
         {
             use tokio::io::AsyncWriteExt;
-            let io = writer.get_mut();
+            let io = writer.inner.get_mut();
             io.write_all(&(encoded.len() as u32).to_be_bytes())
                 .await
                 .unwrap();
@@ -255,7 +284,7 @@ mod tests {
         // Deliver the rest; the buffered prefix must still be intact.
         {
             use tokio::io::AsyncWriteExt;
-            let io = writer.get_mut();
+            let io = writer.inner.get_mut();
             io.write_all(&encoded[4..]).await.unwrap();
             io.flush().await.unwrap();
         }
@@ -282,6 +311,45 @@ mod tests {
         assert_eq!(buffered_frames(&reader), 1);
 
         let _ = recv_batch(&mut reader).await.unwrap();
+        assert_eq!(buffered_frames(&reader), 0);
+    }
+
+    /// A half-arrived frame leaves the codec holding a consumed length prefix, so the
+    /// read buffer starts at payload bytes. Those must never be counted as frames.
+    #[tokio::test]
+    async fn buffered_frames_ignores_a_partial_frame() {
+        let (a, b) = duplex(64 * 1024);
+        let mut writer = wrap(a);
+        let mut reader = wrap(b);
+
+        // A payload whose leading bytes would themselves read as a plausible length
+        // prefix if mistaken for the start of a frame.
+        let messages = vec![CanonicalMessage::from_vec(&[0u8; 64])];
+        let encoded = rmp_serde::to_vec(&messages).unwrap();
+
+        {
+            use tokio::io::AsyncWriteExt;
+            let io = writer.inner.get_mut();
+            io.write_all(&(encoded.len() as u32).to_be_bytes())
+                .await
+                .unwrap();
+            io.write_all(&encoded[..8]).await.unwrap();
+            io.flush().await.unwrap();
+        }
+
+        // Drive a read so the codec consumes the prefix and parks mid-frame.
+        assert!(try_recv_batch(&mut reader).unwrap().is_none());
+        assert_eq!(buffered_frames(&reader), 0);
+
+        // Once the frame completes, counting resumes.
+        {
+            use tokio::io::AsyncWriteExt;
+            let io = writer.inner.get_mut();
+            io.write_all(&encoded[8..]).await.unwrap();
+            io.flush().await.unwrap();
+        }
+        let received = recv_batch(&mut reader).await.unwrap();
+        assert_eq!(received[0].payload.len(), 64);
         assert_eq!(buffered_frames(&reader), 0);
     }
 }

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -364,7 +364,7 @@ fn check_consumer_recursive(
             }
             Ok(warnings)
         }
-        #[cfg(feature = "zeromq")]
+        #[cfg(any(feature = "zeromq", feature = "zeromq-omq"))]
         EndpointType::ZeroMq(_) => Ok(warnings),
         #[cfg(feature = "redis-streams")]
         EndpointType::RedisStreams(cfg) => {
@@ -1171,7 +1171,7 @@ fn check_publisher_recursive(
             }
             Ok(warnings)
         }
-        #[cfg(feature = "zeromq")]
+        #[cfg(any(feature = "zeromq", feature = "zeromq-omq"))]
         EndpointType::ZeroMq(cfg) => {
             if cfg.topic.is_some() {
                 warnings.push(

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -1909,6 +1909,7 @@ mod tests {
                 store: None,
                 sled_path: Some("".into()),
                 ttl_seconds: 10,
+                key: None,
             })
             .with_consumer_metrics();
 

--- a/src/endpoints/mongodb/consumer.rs
+++ b/src/endpoints/mongodb/consumer.rs
@@ -248,13 +248,13 @@ impl MongoDbConsumer {
             .sort(doc! { "_id": 1 })
             .await?;
 
-        let mut ids_to_claim = Vec::new();
+        // Any `_id` type is claimable — ObjectId, string, integer, UUID binary. Restricting
+        // this to UUIDs would silently skip documents `try_claim_document` picks up fine.
+        let mut ids_to_claim: Vec<Bson> = Vec::new();
         while let Some(result) = cursor.next().await {
             if let Ok(doc) = result {
-                if let Some(Bson::Binary(binary)) = doc.get("_id") {
-                    if let Ok(uuid) = binary.to_uuid() {
-                        ids_to_claim.push(uuid);
-                    }
+                if let Some(id) = doc.get("_id") {
+                    ids_to_claim.push(id.clone());
                 }
             }
         }
@@ -272,7 +272,7 @@ impl MongoDbConsumer {
 
         // If we successfully modified any documents, retrieve their full content.
         if update_result.modified_count > 0 {
-            self.get_documents_by_ids(&ids_to_claim).await
+            self.get_documents_by_ids(&ids_to_claim, locked_until).await
         } else {
             Ok(Vec::new())
         }
@@ -376,12 +376,17 @@ impl MongoDbConsumer {
         }
     }
 
-    /// Retrieves documents by their IDs.
+    /// Retrieves the documents this claim locked.
+    ///
+    /// The candidate ids were gathered before the update, so a concurrent consumer may
+    /// have taken some of them. Matching on the exact `locked_until` we wrote narrows the
+    /// result to the documents this call actually won.
     async fn get_documents_by_ids(
         &self,
-        claimed_ids: &[mongodb::bson::Uuid],
+        claimed_ids: &[Bson],
+        locked_until: i64,
     ) -> anyhow::Result<Vec<Document>> {
-        let filter = doc! { "_id": { "$in": claimed_ids } };
+        let filter = doc! { "_id": { "$in": claimed_ids }, "locked_until": locked_until };
         let mut cursor = self
             .collection
             .find(filter)

--- a/src/endpoints/mongodb/readers.rs
+++ b/src/endpoints/mongodb/readers.rs
@@ -689,9 +689,15 @@ impl MessageConsumer for MongoDbChangeStreamReader {
         // immediately-available events into the batch with a short timeout. While idle, periodically
         // advance the durable checkpoint to the stream's postBatchResumeToken so it can't age out of
         // the oplog (guarded so it never skips an un-acked change).
+        //
+        // Polls with `next_if_any` rather than `StreamExt::next`: a `next()` future cancelled by the
+        // timeout leaves the driver's stream state non-`Idle`, and `resume_token()` panics on any
+        // other state. `next_if_any` borrows the stream instead of replacing that state, so the
+        // token stays readable when the timeout fires mid-poll.
+        let mut last_refresh = Instant::now();
         loop {
-            match tokio::time::timeout(IDLE_RESUME_REFRESH, stream.next()).await {
-                Ok(Some(Ok(event))) => {
+            match tokio::time::timeout(IDLE_RESUME_REFRESH, stream.next_if_any()).await {
+                Ok(Ok(Some(event))) => {
                     let token = event.id.clone();
                     if let Some(msg) = Self::event_to_message(&event) {
                         messages.push(msg);
@@ -702,28 +708,33 @@ impl MessageConsumer for MongoDbChangeStreamReader {
                     }
                     // Event carried no payload (e.g. a drop); keep waiting for a real change.
                 }
-                Ok(Some(Err(e))) => return Err(ConsumerError::Connection(e.into())),
-                Ok(None) => return Err(anyhow!("MongoDB change stream ended unexpectedly").into()),
-                Err(_) => {
-                    // Extract the token synchronously (stream ref isn't `Send`), then persist.
-                    let token = stream.resume_token();
-                    self.refresh_idle_checkpoint(token).await;
+                Ok(Err(e)) => return Err(ConsumerError::Connection(e.into())),
+                // No change ready: the getMore came back empty, or it outran the refresh interval.
+                Ok(Ok(None)) | Err(_) => {
+                    if !stream.is_alive() {
+                        return Err(anyhow!("MongoDB change stream ended unexpectedly").into());
+                    }
+                    if last_refresh.elapsed() >= IDLE_RESUME_REFRESH {
+                        // Extract the token synchronously (stream ref isn't `Send`), then persist.
+                        let token = stream.resume_token();
+                        self.refresh_idle_checkpoint(token).await;
+                        last_refresh = Instant::now();
+                    }
                 }
             }
         }
 
         while messages.len() < max_messages {
-            match tokio::time::timeout(Duration::from_millis(10), stream.next()).await {
-                Ok(Some(Ok(event))) => {
+            match tokio::time::timeout(Duration::from_millis(10), stream.next_if_any()).await {
+                Ok(Ok(Some(event))) => {
                     let token = event.id.clone();
                     if let Some(msg) = Self::event_to_message(&event) {
                         messages.push(msg);
                         tokens.push(token);
                     }
                 }
-                Ok(Some(Err(e))) => return Err(ConsumerError::Connection(e.into())),
-                Ok(None) => return Err(anyhow!("MongoDB change stream ended unexpectedly").into()),
-                Err(_) => break, // no more events ready right now
+                Ok(Err(e)) => return Err(ConsumerError::Connection(e.into())),
+                Ok(Ok(None)) | Err(_) => break, // no more events ready right now
             }
         }
 

--- a/src/endpoints/nats.rs
+++ b/src/endpoints/nats.rs
@@ -521,6 +521,35 @@ async fn build_nats_options(config: &NatsConfig) -> anyhow::Result<ConnectOption
     Ok(options)
 }
 
+/// True for JetStream setup failures a reconnect cannot change: the stream exists but its
+/// configuration is incompatible with the route's `stream`/`subject` (most often the subject
+/// is not covered by the stream's subjects). Retrying rebuilds the identical mismatch.
+fn is_permanent_jetstream_setup_error(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("filter subject")
+        || m.contains("does not match any subject")
+        || m.contains("subjects overlap")
+        || m.contains("stream name already in use")
+}
+
+/// Classify a JetStream setup failure so a configuration mismatch stops the route instead of
+/// spinning on the reconnect interval forever. Connect/IO failures stay retryable.
+fn classify_jetstream_setup_error(
+    e: impl std::fmt::Display,
+    stream: &str,
+    subject: &str,
+) -> anyhow::Error {
+    let msg = format!("NATS JetStream setup failed (stream '{stream}', subject '{subject}'): {e}");
+    if is_permanent_jetstream_setup_error(&msg) {
+        anyhow::Error::new(ConsumerError::Permanent(anyhow!(
+            "{msg}. This is a configuration mismatch, not a transient failure: reconcile the \
+             route's `stream`/`subject` with the existing stream, or update the stream."
+        )))
+    } else {
+        anyhow!(msg)
+    }
+}
+
 impl NatsCore {
     async fn connect(
         config: &NatsConfig,
@@ -546,7 +575,8 @@ impl NatsCore {
                     max_bytes: config.stream_max_bytes.unwrap_or(1024 * 1024 * 1024), // 1GB
                     ..Default::default()
                 })
-                .await?;
+                .await
+                .map_err(|e| classify_jetstream_setup_error(e, stream_name, subject))?;
 
             let stream = jetstream.get_stream(stream_name).await?;
 
@@ -559,7 +589,8 @@ impl NatsCore {
                     max_ack_pending,
                     ..Default::default()
                 })
-                .await?;
+                .await
+                .map_err(|e| classify_jetstream_setup_error(e, stream_name, subject))?;
 
             let stream = consumer.messages().await?;
             info!(stream = %stream_name, subject = %subject, "NATS JetStream subscribed");

--- a/src/endpoints/object_store.rs
+++ b/src/endpoints/object_store.rs
@@ -516,6 +516,18 @@ impl ObjectStoreConsumer {
         Ok(None)
     }
 
+    /// Bound on decompressed output.
+    ///
+    /// `max_object_bytes` caps the *stored* size (see `next_object`), so reusing it here
+    /// would reject any object that compressed better than 1:1 — i.e. most of them. Scale
+    /// it instead; the result is still bounded, so a decompression bomb cannot run away.
+    #[cfg(feature = "compression")]
+    fn decompressed_limit(&self) -> Option<u64> {
+        const MAX_DECOMPRESSED_EXPANSION: u64 = 20;
+        self.max_object_bytes
+            .map(|limit| limit.saturating_mul(MAX_DECOMPRESSED_EXPANSION))
+    }
+
     /// Decrypt-then-decompress a fetched object whole (the write path compressed first).
     #[allow(unused_variables)]
     fn decode_object(&self, key: &str, data: Vec<u8>) -> anyhow::Result<Vec<u8>> {
@@ -532,7 +544,7 @@ impl ObjectStoreConsumer {
             crate::support::compression::decompress_all(
                 self.compression,
                 &data,
-                self.max_object_bytes,
+                self.decompressed_limit(),
             )
             .with_context(|| format!("decompress object '{key}'"))?
         } else {

--- a/src/endpoints/object_store.rs
+++ b/src/endpoints/object_store.rs
@@ -37,21 +37,10 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{info, trace, warn};
 
-/// Builds an `object_store` backend and its base prefix `Path` from a URL. Credentials and
-/// backend options (`AWS_ACCESS_KEY_ID`, `AWS_ENDPOINT`, `AWS_REGION`, `AWS_ALLOW_HTTP`,
-/// `GOOGLE_SERVICE_ACCOUNT`, ...) are read from the process environment.
-///
-/// The backend config-key parsers only accept the lowercase form (`aws_access_key_id`), so
-/// env-var names are lowercased before being folded into the builder — the same
-/// normalization `AmazonS3Builder::from_env` does. Unrecognized keys are ignored. Bare
-/// `parse_url` reads no env at all, which would fall through to the EC2/GCE metadata service.
-fn build_store(url: &str) -> anyhow::Result<(Box<dyn ObjectStore>, ObjPath)> {
-    let parsed =
-        url::Url::parse(url).with_context(|| format!("Invalid object_store url '{url}'"))?;
-    let env = std::env::vars().map(|(k, v)| (k.to_ascii_lowercase(), v));
-    object_store::parse_url_opts(&parsed, env)
-        .with_context(|| format!("Failed to build object store for '{url}'"))
-}
+/// Builds an `object_store` backend and its base prefix `Path` from a URL, reading
+/// credentials from the environment. Shared with the object-store checkpoint backend so
+/// both resolve creds identically — see [`checkpoint::object_store_backend::build_store`].
+use crate::checkpoint::object_store_backend::build_store;
 
 /// True if two object-store URLs share a scheme+host and one's path segments are a prefix
 /// of the other's — i.e. a recursive `list` of one would surface objects of the other.
@@ -385,19 +374,22 @@ impl ObjectStoreConsumer {
         ) {
             (Some(cid), Some(spec)) => match checkpoint::parse_checkpoint_store(spec)? {
                 CheckpointBackend::Source { .. } => {
-                    return Err(anyhow!(
+                    // Same misconfiguration class as the overlap check below: permanent.
+                    return Err(anyhow::Error::new(ConsumerError::Permanent(anyhow!(
                             "object_store source requires an external checkpoint_store (file://, s3://, postgres://, or mongodb://); a source-datastore checkpoint is not available."
-                        ));
+                        ))));
                 }
                 external => {
                     // Guard against the cursor object landing under the source prefix, where
                     // it would be listed and re-emitted as data.
                     if let CheckpointBackend::ObjectStore { url: ck_url } = &external {
                         if object_urls_overlap(&config.url, ck_url) {
-                            return Err(anyhow!(
+                            // Misconfiguration: rebuilding the consumer reads the same config,
+                            // so this must stop the route rather than reconnect forever.
+                            return Err(anyhow::Error::new(ConsumerError::Permanent(anyhow!(
                                 "object_store checkpoint_store '{ck_url}' overlaps the source prefix '{}'; the cursor object would be listed and re-read as data. Point checkpoint_store at a different bucket or prefix.",
                                 config.url
-                            ));
+                            ))));
                         }
                     }
                     Some(checkpoint::build_external_store(external, &config.url, cid).await?)
@@ -501,12 +493,13 @@ impl ObjectStoreConsumer {
                 continue;
             }
             // Refuse to materialize an over-large object; the listing already carries its size.
+            // The object will not shrink, so retrying re-lists it forever: fail permanently.
             if let Some(limit) = self.max_object_bytes {
                 if meta.size > limit {
-                    return Err(anyhow!(
-                        "object '{key}' is {} bytes, exceeding max_object_bytes ({limit}); refusing to buffer it whole",
+                    return Err(anyhow::Error::new(ConsumerError::Permanent(anyhow!(
+                        "object '{key}' is {} bytes, exceeding max_object_bytes ({limit}); refusing to buffer it whole. Raise max_object_bytes or remove the object.",
                         meta.size
-                    ));
+                    ))));
                 }
             }
             let data = self
@@ -577,10 +570,12 @@ impl MessageConsumer for ObjectStoreConsumer {
             let in_flight = self.progress.lock().await.is_some();
             if buffer_empty && !in_flight {
                 let last = self.last_key.lock().await.clone();
+                // `from` (not `Connection`) so a permanent listing failure — e.g. an object
+                // over `max_object_bytes` — is not retried as a transport blip.
                 match self
                     .next_object(last.as_deref())
                     .await
-                    .map_err(ConsumerError::Connection)?
+                    .map_err(ConsumerError::from)?
                 {
                     None => {
                         tokio::time::sleep(self.idle_delay).await;

--- a/src/endpoints/postgres/mod.rs
+++ b/src/endpoints/postgres/mod.rs
@@ -31,7 +31,7 @@ use pgwire_replication::{Lsn, ReplicationClient};
 use replication::ReplicationEvent;
 use std::any::Any;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
@@ -60,6 +60,10 @@ pub struct PostgresCdcConsumer {
     /// TLS config used on teardown to reopen the control-plane connection (see `Drop`).
     tls: crate::models::TlsConfig,
     ended: bool,
+    /// `temporary_slot`: drop the slot on teardown instead of advancing it.
+    drop_slot_on_stop: bool,
+    /// Set once teardown has run, so the `Drop` fallback never repeats the hook's work.
+    teardown_done: AtomicBool,
     /// Drain mode: only then does an idle replication read time out into an empty batch.
     exit_on_empty: bool,
 }
@@ -167,8 +171,43 @@ impl PostgresCdcConsumer {
             slot_name: config.slot_name.clone(),
             tls: config.tls.clone(),
             ended: false,
+            drop_slot_on_stop: config.temporary_slot,
+            teardown_done: AtomicBool::new(false),
             exit_on_empty: false,
         })
+    }
+
+    /// Release the slot: stop the stream, then either drop the slot (ephemeral run) or
+    /// advance its `confirmed_flush_lsn` to the last acked position.
+    ///
+    /// Runs at most once. Both branches need a fresh control-plane connection —
+    /// `pg_replication_slot_advance` and `pg_drop_replication_slot` are ordinary SQL, not
+    /// replication commands — which is why this belongs in `on_disconnect_hook` (awaited by
+    /// the route while the runtime is still healthy) rather than in `Drop`, where opening a
+    /// connection during runtime teardown fails with "task was cancelled".
+    async fn teardown(&self) {
+        if self.teardown_done.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let lsn = self.confirmed.load(Ordering::Acquire);
+        if lsn == 0 && !self.drop_slot_on_stop {
+            return;
+        }
+        // CopyDone; the worker exits and the server releases the slot shortly after. Both
+        // helpers below poll `pg_replication_slots.active` until then.
+        self.client.stop();
+        if self.drop_slot_on_stop {
+            // Ephemeral run: the slot is discarded, so its confirmed_flush_lsn is
+            // irrelevant — dropping it releases the retained WAL outright.
+            if let Err(e) = replication::drop_slot(&self.url, &self.slot_name, &self.tls).await {
+                warn!(error = %e, "postgres_cdc: dropping ephemeral slot on shutdown failed");
+            }
+        } else if let Err(e) =
+            replication::advance_slot_when_inactive(&self.url, &self.slot_name, lsn, &self.tls)
+                .await
+        {
+            warn!(error = %e, "postgres_cdc: durable slot advance on shutdown failed");
+        }
     }
 
     /// Push the current confirmed LSN to the server as the slot's applied position.
@@ -392,6 +431,15 @@ impl MessageConsumer for PostgresCdcConsumer {
     fn set_exit_on_empty(&mut self, exit_on_empty: bool) {
         self.exit_on_empty = exit_on_empty;
     }
+
+    /// Release the slot while the runtime is still healthy — see [`Self::teardown`].
+    fn on_disconnect_hook(&self) -> Option<crate::traits::BoxFuture<'_, anyhow::Result<()>>> {
+        Some(Box::pin(async move {
+            self.teardown().await;
+            Ok(())
+        }))
+    }
+
     async fn receive_batch(&mut self, max_messages: usize) -> Result<ReceivedBatch, ConsumerError> {
         if max_messages == 0 {
             return Ok(ReceivedBatch {
@@ -426,9 +474,13 @@ impl MessageConsumer for PostgresCdcConsumer {
                     self.handle_event(ev).map_err(ConsumerError::Connection)?;
                 }
                 Err(e) => {
-                    return Err(ConsumerError::Connection(anyhow!(
-                        "postgres_cdc: recv failed: {e}"
-                    )));
+                    let msg = format!("postgres_cdc: recv failed: {e}");
+                    // A vanished slot never comes back on its own; don't reconnect-loop.
+                    return Err(if replication::is_missing_slot_error(&msg) {
+                        ConsumerError::Permanent(anyhow!(msg))
+                    } else {
+                        ConsumerError::Connection(anyhow!(msg))
+                    });
                 }
             }
         }
@@ -511,9 +563,20 @@ impl MessageConsumer for PostgresCdcConsumer {
 /// current-thread runtime (or off-runtime) we fall back to the best-effort async
 /// feedback already sent during streaming.
 impl Drop for PostgresCdcConsumer {
+    /// Best-effort fallback for consumers dropped without a graceful stop (direct API use,
+    /// a panicking route). The route path runs `on_disconnect_hook` first, and `teardown`
+    /// is single-shot, so this is normally a no-op.
+    ///
+    /// It stays best-effort on purpose: opening the control-plane connection from here
+    /// fails once the runtime has started cancelling tasks, which is exactly why the real
+    /// teardown moved into the disconnect hook.
     fn drop(&mut self) {
+        if self.teardown_done.load(Ordering::Acquire) {
+            return;
+        }
         let lsn = self.confirmed.load(Ordering::Acquire);
-        if lsn == 0 {
+        // With no acked position and nothing to clean up there is no teardown work.
+        if lsn == 0 && !self.drop_slot_on_stop {
             return;
         }
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
@@ -522,22 +585,7 @@ impl Drop for PostgresCdcConsumer {
         if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::CurrentThread {
             return;
         }
-        let url = self.url.clone();
-        let slot = self.slot_name.clone();
-        let tls = self.tls.clone();
-        let client = &mut self.client;
-        tokio::task::block_in_place(|| {
-            handle.block_on(async move {
-                // Stop the stream so the server releases the slot, then advance
-                // confirmed_flush_lsn to the last durably-acked LSN.
-                let _ = client.shutdown().await;
-                if let Err(e) =
-                    replication::advance_slot_when_inactive(&url, &slot, lsn, &tls).await
-                {
-                    warn!(error = %e, "postgres_cdc: durable slot advance on shutdown failed");
-                }
-            });
-        });
+        tokio::task::block_in_place(|| handle.block_on(self.teardown()));
     }
 }
 

--- a/src/endpoints/postgres/mod.rs
+++ b/src/endpoints/postgres/mod.rs
@@ -432,7 +432,7 @@ impl MessageConsumer for PostgresCdcConsumer {
         self.exit_on_empty = exit_on_empty;
     }
 
-    /// Release the slot while the runtime is still healthy — see [`Self::teardown`].
+    /// Release the slot while the runtime is still healthy — see `teardown`.
     fn on_disconnect_hook(&self) -> Option<crate::traits::BoxFuture<'_, anyhow::Result<()>>> {
         Some(Box::pin(async move {
             self.teardown().await;

--- a/src/endpoints/postgres/replication.rs
+++ b/src/endpoints/postgres/replication.rs
@@ -118,11 +118,18 @@ async fn control_conn(url: &str, tls: &crate::models::TlsConfig) -> anyhow::Resu
 
 /// Ensure the logical replication slot exists, creating it with the `pgoutput`
 /// plugin if missing and `create_if_missing` is true.
+///
+/// The slot is always created as **permanent**, even for an ephemeral run. A
+/// Postgres *temporary* slot lives and dies with the session that created it, and
+/// the streaming connection is a separate session from this control connection —
+/// so a temporary slot would be gone before `START_REPLICATION` could use it.
+/// Ephemeral runs (`temporary_slot: true`) instead get the slot dropped on
+/// teardown; see [`drop_slot`] and `PostgresCdcConsumer`'s `Drop`.
 pub async fn ensure_slot(
     url: &str,
     slot_name: &str,
     create_if_missing: bool,
-    temporary: bool,
+    drop_on_stop: bool,
     tls: &crate::models::TlsConfig,
 ) -> anyhow::Result<()> {
     let mut conn = control_conn(url, tls).await?;
@@ -144,15 +151,17 @@ pub async fn ensure_slot(
         ));
     }
 
-    sqlx::query("SELECT pg_create_logical_replication_slot($1, 'pgoutput', $2)")
+    sqlx::query("SELECT pg_create_logical_replication_slot($1, 'pgoutput', false)")
         .bind(slot_name)
-        .bind(temporary)
         .execute(&mut conn)
         .await
         .map_err(|e| anyhow!("postgres-cdc: create slot failed: {e}"))?;
 
-    if temporary {
-        debug!("postgres-cdc: created temporary replication slot '{slot_name}'");
+    if drop_on_stop {
+        debug!(
+            "postgres-cdc: created replication slot '{slot_name}'; it is dropped again when the \
+             route stops (temporary_slot: true)"
+        );
     } else {
         warn!(
             "postgres-cdc: created PERMANENT replication slot '{slot_name}' — it retains WAL on \
@@ -161,6 +170,63 @@ pub async fn ensure_slot(
         );
     }
     Ok(())
+}
+
+/// Drop the replication slot, waiting for the server to release it first.
+/// `pg_drop_replication_slot` refuses to run while a walsender still holds the
+/// slot, and the server releases it only shortly after the streaming socket
+/// closes — so poll `pg_replication_slots.active` the same way
+/// [`advance_slot_when_inactive`] does. A slot that is already gone is a no-op.
+pub async fn drop_slot(
+    url: &str,
+    slot_name: &str,
+    tls: &crate::models::TlsConfig,
+) -> anyhow::Result<()> {
+    let mut conn = control_conn(url, tls).await?;
+    if !wait_for_slot_release(&mut conn, slot_name).await? {
+        return Ok(());
+    }
+    sqlx::query("SELECT pg_drop_replication_slot($1)")
+        .bind(slot_name)
+        .execute(&mut conn)
+        .await
+        .map_err(|e| anyhow!("postgres-cdc: drop slot failed: {e}"))?;
+    debug!("postgres-cdc: dropped replication slot '{slot_name}'");
+    Ok(())
+}
+
+/// Poll `pg_replication_slots.active` until the walsender lets go of the slot. Both
+/// `pg_replication_slot_advance` and `pg_drop_replication_slot` refuse to run on an active
+/// slot, and the server releases it only shortly after the streaming socket closes.
+///
+/// Returns `false` when the slot no longer exists (nothing left to do), `true` once it is
+/// inactive — or after the budget runs out, letting the caller's statement produce the real
+/// server error rather than a synthetic timeout.
+async fn wait_for_slot_release(conn: &mut PgConnection, slot_name: &str) -> anyhow::Result<bool> {
+    // ~5s: the stream is asked to stop just before this, but CopyDone plus the server's
+    // walsender cleanup is a round trip, and this runs once per route stop.
+    for _ in 0..200 {
+        let active: Option<(Option<bool>,)> =
+            sqlx::query_as("SELECT active FROM pg_replication_slots WHERE slot_name = $1")
+                .bind(slot_name)
+                .fetch_optional(&mut *conn)
+                .await
+                .map_err(|e| anyhow!("postgres-cdc: slot status check failed: {e}"))?;
+        match active {
+            None => return Ok(false),
+            Some((Some(false) | None,)) => return Ok(true),
+            Some((Some(true),)) => tokio::time::sleep(Duration::from_millis(25)).await,
+        }
+    }
+    warn!("postgres-cdc: replication slot '{slot_name}' still active after 5s; proceeding anyway");
+    Ok(true)
+}
+
+/// True when an error reports that the replication slot is gone (SQLSTATE 42704,
+/// `undefined_object`). Reconnecting cannot recreate it, so the route must fail
+/// permanently rather than retry on the reconnect interval forever.
+pub fn is_missing_slot_error(msg: &str) -> bool {
+    msg.contains("42704") || (msg.contains("replication slot") && msg.contains("does not exist"))
 }
 
 /// A publication table reference is a plain identifier or a single `schema.table`,
@@ -346,21 +412,8 @@ pub async fn advance_slot_when_inactive(
         return Ok(());
     }
     let mut conn = control_conn(url, tls).await?;
-    for _ in 0..40 {
-        let active: Option<(Option<bool>,)> =
-            sqlx::query_as("SELECT active FROM pg_replication_slots WHERE slot_name = $1")
-                .bind(slot_name)
-                .fetch_optional(&mut conn)
-                .await
-                .map_err(|e| anyhow!("postgres-cdc: slot status check failed: {e}"))?;
-        match active {
-            // Slot no longer exists — nothing to advance.
-            None => return Ok(()),
-            // Inactive (or NULL) — safe to advance.
-            Some((Some(false) | None,)) => break,
-            // Still held by a walsender — wait for release.
-            Some((Some(true),)) => tokio::time::sleep(Duration::from_millis(25)).await,
-        }
+    if !wait_for_slot_release(&mut conn, slot_name).await? {
+        return Ok(());
     }
     sqlx::query("SELECT pg_replication_slot_advance($1, $2::pg_lsn)")
         .bind(slot_name)
@@ -395,7 +448,14 @@ pub async fn start_replication(
     .with_status_interval(status_interval)
     .with_wakeup_interval(status_interval);
 
-    ReplicationClient::connect(cfg)
-        .await
-        .map_err(|e| anyhow!("postgres-cdc: start_replication failed: {e}"))
+    ReplicationClient::connect(cfg).await.map_err(|e| {
+        let msg = format!("postgres-cdc: start_replication failed: {e}");
+        // A missing slot cannot heal itself; surface it as permanent so the route
+        // stops instead of reconnecting on the interval forever.
+        if is_missing_slot_error(&msg) {
+            anyhow::Error::new(crate::errors::ConsumerError::Permanent(anyhow!(msg)))
+        } else {
+            anyhow!(msg)
+        }
+    })
 }

--- a/src/endpoints/redis_streams.rs
+++ b/src/endpoints/redis_streams.rs
@@ -436,7 +436,13 @@ fn spawn_stream_reader(ctx: ReaderCtx) {
                 Ok(None) => {}
                 // Client-side read timeout: same "no data" condition as `Ok(None)`,
                 // it just fired before the server's empty BLOCK reply arrived.
-                Err(e) if e.is_timeout() => {}
+                Err(e) if e.is_timeout() => {
+                    trace!(
+                        stream = %task_stream,
+                        error = %e,
+                        "Redis XREAD client-side read timeout; polling again"
+                    );
+                }
                 Err(e) => {
                     if tx
                         .send(Err(ConsumerError::Connection(anyhow!(

--- a/src/endpoints/redis_streams.rs
+++ b/src/endpoints/redis_streams.rs
@@ -31,8 +31,10 @@ use redis::streams::{
 use redis::{AsyncCommands, IntoConnectionInfo};
 use std::any::Any;
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tracing::trace;
+use tracing::{trace, warn};
 
 /// The stream field used to carry the raw message payload.
 const PAYLOAD_FIELD: &str = "payload";
@@ -215,6 +217,15 @@ pub struct RedisStreamsConsumer {
     /// idle read time out into an empty batch; otherwise it blocks indefinitely
     /// (event-driven, no added latency) as a streaming source should.
     exit_on_empty: bool,
+    /// Every consumer name this instance reads under, for the own-PEL health probe.
+    consumer_names: Vec<String>,
+    redelivery_ms: u64,
+    /// Entries handed to the route, and entries the route has since settled
+    /// (acked or nacked). Equal means nothing is in flight downstream.
+    delivered: Arc<AtomicU64>,
+    settled: Arc<AtomicU64>,
+    /// When the "own PEL non-empty with nothing in flight" state was first seen.
+    stuck_since: std::sync::Mutex<Option<Instant>>,
 }
 
 impl RedisStreamsConsumer {
@@ -286,6 +297,7 @@ impl RedisStreamsConsumer {
         let (tx, rx) =
             bounded::<Result<StreamEntry, ConsumerError>>(count.saturating_mul(readers).max(count));
 
+        let mut consumer_names = Vec::with_capacity(readers);
         for i in 0..readers {
             // Reader 0 reuses the connection the group was created on; the rest get
             // their own so one reader's blocking XREAD never stalls a sibling.
@@ -302,16 +314,30 @@ impl RedisStreamsConsumer {
             } else {
                 format!("{}-{}", consumer_name, i)
             };
+            consumer_names.push(consumer_name.clone());
+            // Only one reader runs the reclaim pass, to avoid N-way XAUTOCLAIM contention.
+            // It gets its own connection: XAUTOCLAIM must not share the multiplexed
+            // connection that is parked in `XREAD BLOCK`, or the claim can succeed
+            // server-side while the reply times out client-side, stranding the entries
+            // in this consumer's PEL with their idle time reset on every retry.
+            let reclaim_conn = if i == 0 && group.is_some() && redelivery_ms > 0 {
+                Some(
+                    ConnectionManager::new(client.clone())
+                        .await
+                        .map_err(|e| anyhow!("Failed to connect to Redis: {}", e))?,
+                )
+            } else {
+                None
+            };
             spawn_stream_reader(ReaderCtx {
                 read_conn,
+                reclaim_conn,
                 stream: stream.clone(),
                 group: group.clone(),
                 consumer_name,
                 count,
                 block_ms,
                 redelivery_ms,
-                // Only one reader runs the reclaim pass, to avoid N-way XAUTOCLAIM contention.
-                reclaim: i == 0,
                 tx: tx.clone(),
             });
         }
@@ -324,13 +350,81 @@ impl RedisStreamsConsumer {
             group,
             buffer: VecDeque::new(),
             exit_on_empty: false,
+            consumer_names,
+            redelivery_ms,
+            delivered: Arc::new(AtomicU64::new(0)),
+            settled: Arc::new(AtomicU64::new(0)),
+            stuck_since: std::sync::Mutex::new(None),
         })
     }
 }
 
+impl RedisStreamsConsumer {
+    /// Detects entries stuck in *this* consumer's own PEL: claimed from the group but
+    /// never delivered onward. That state is unreachable in normal operation — every
+    /// entry we own is either buffered here, in flight downstream, or waiting to be
+    /// reclaimed — so once it persists it means the reader has wedged. It used to be
+    /// invisible, with the route reporting a healthy idle consumer forever.
+    ///
+    /// Returns the error message when stalled. Requires reclaiming to be enabled;
+    /// with `redelivery_timeout_ms: 0` a permanently pending entry is the configured
+    /// behaviour, not a fault.
+    async fn stalled_own_pending(&self, conn: &mut ConnectionManager) -> Option<String> {
+        let clear = || *self.stuck_since.lock().unwrap() = None;
+        let Some(group) = &self.group else {
+            return None;
+        };
+        // Anything queued locally, or still unsettled downstream, is progress.
+        if self.redelivery_ms == 0
+            || !self.buffer.is_empty()
+            || !self.rx.is_empty()
+            || self.delivered.load(Ordering::Relaxed) != self.settled.load(Ordering::Relaxed)
+        {
+            clear();
+            return None;
+        }
+
+        let mut pending = 0usize;
+        for name in &self.consumer_names {
+            let reply: redis::RedisResult<redis::streams::StreamPendingCountReply> = conn
+                .xpending_consumer_count(&self.stream, group, "-", "+", 1, name)
+                .await;
+            match reply {
+                Ok(reply) => pending += reply.ids.len(),
+                // Can't tell; leave the verdict to the next poll.
+                Err(_) => return None,
+            }
+        }
+        if pending == 0 {
+            clear();
+            return None;
+        }
+
+        // Grace period: a nacked entry legitimately sits in our PEL until the
+        // reclaim pass redelivers it, which takes up to redelivery_ms.
+        let grace = Duration::from_millis(self.redelivery_ms.saturating_mul(2)).max(TEN_SECONDS);
+        let mut stuck_since = self.stuck_since.lock().unwrap();
+        let since = stuck_since.get_or_insert_with(Instant::now);
+        if since.elapsed() < grace {
+            return None;
+        }
+        Some(format!(
+            "Redis consumer stalled: entries pending under this consumer's own name in group '{}' \
+             with nothing in flight for {:?}",
+            group,
+            since.elapsed()
+        ))
+    }
+}
+
+const TEN_SECONDS: Duration = Duration::from_secs(10);
+
 /// Parameters for a single background stream-reader task.
 struct ReaderCtx {
     read_conn: ConnectionManager,
+    /// Dedicated connection for the XAUTOCLAIM reclaim pass; `Some` on the one
+    /// reader that runs it. Never shared with the blocking read connection.
+    reclaim_conn: Option<ConnectionManager>,
     stream: String,
     /// `Some` in consumer-group mode; `None` in subscriber mode.
     group: Option<String>,
@@ -338,8 +432,6 @@ struct ReaderCtx {
     count: usize,
     block_ms: usize,
     redelivery_ms: u64,
-    /// Whether this reader runs the XAUTOCLAIM reclaim pass (only one should).
-    reclaim: bool,
     tx: Sender<Result<StreamEntry, ConsumerError>>,
 }
 
@@ -348,19 +440,18 @@ struct ReaderCtx {
 fn spawn_stream_reader(ctx: ReaderCtx) {
     let ReaderCtx {
         mut read_conn,
+        mut reclaim_conn,
         stream: task_stream,
         group: task_group,
         consumer_name,
         count,
         block_ms,
         redelivery_ms,
-        reclaim,
         tx,
     } = ctx;
     tokio::spawn(async move {
         // In subscriber mode we track the last delivered id ("$" = new only).
         let mut last_id = String::from("$");
-        let reclaim_enabled = reclaim && task_group.is_some() && redelivery_ms > 0;
         // Check for reclaimable entries on the read cadence; eligibility is
         // still gated by redelivery_ms of idleness on the server side.
         let reclaim_interval = Duration::from_millis(redelivery_ms.min(block_ms as u64).max(1000));
@@ -371,11 +462,11 @@ fn spawn_stream_reader(ctx: ReaderCtx) {
         loop {
             // Redeliver entries left pending past redelivery_ms (Nacked, or
             // orphaned by a crashed/renamed consumer) via XAUTOCLAIM.
-            if reclaim_enabled && last_reclaim.is_none_or(|t| t.elapsed() >= reclaim_interval) {
+            if last_reclaim.is_none_or(|t| t.elapsed() >= reclaim_interval) {
                 last_reclaim = Some(Instant::now());
-                if let Some(group) = &task_group {
+                if let (Some(group), Some(conn)) = (&task_group, reclaim_conn.as_mut()) {
                     let claim_opts = StreamAutoClaimOptions::default().count(count);
-                    let claimed: redis::RedisResult<StreamAutoClaimReply> = read_conn
+                    let claimed: redis::RedisResult<StreamAutoClaimReply> = conn
                         .xautoclaim_options(
                             &task_stream,
                             group,
@@ -397,9 +488,12 @@ fn spawn_stream_reader(ctx: ReaderCtx) {
                                 }
                             }
                         }
-                        // Transient; a hard error surfaces on the read below.
+                        // Transient; a hard error surfaces on the read below. Warn
+                        // anyway: a claim that fails after the server applied it
+                        // leaves entries pending under this consumer, and silence
+                        // makes that indistinguishable from an idle stream.
                         Err(e) => {
-                            trace!(stream = %task_stream, error = %e, "Redis XAUTOCLAIM failed")
+                            warn!(stream = %task_stream, error = %e, "Redis XAUTOCLAIM failed")
                         }
                     }
                 }
@@ -552,11 +646,16 @@ impl MessageConsumer for RedisStreamsConsumer {
 
         trace!(stream = %self.stream, count = messages.len(), message_ids = ?LazyMessageIds(&messages), "Received batch of Redis Streams messages");
 
+        self.delivered
+            .fetch_add(messages.len() as u64, Ordering::Relaxed);
+
         let group = self.group.clone();
         let stream = self.stream.clone();
         let mut ack_conn = self.ack_conn.clone();
+        let settled = self.settled.clone();
         let commit = Box::new(move |dispositions: Vec<MessageDisposition>| {
             Box::pin(async move {
+                settled.fetch_add(dispositions.len() as u64, Ordering::Relaxed);
                 // Subscriber mode has no group and therefore nothing to ack.
                 let Some(group) = group else {
                     return Ok(());
@@ -590,15 +689,21 @@ impl MessageConsumer for RedisStreamsConsumer {
             .query_async::<String>(&mut conn)
             .await
             .is_ok();
+        if !healthy {
+            return EndpointStatus {
+                healthy,
+                target: self.stream.clone(),
+                pending: Some(self.buffer.len() + self.rx.len()),
+                error: Some("Redis PING failed".to_string()),
+                ..Default::default()
+            };
+        }
+        let stalled = self.stalled_own_pending(&mut conn).await;
         EndpointStatus {
-            healthy,
+            healthy: stalled.is_none(),
             target: self.stream.clone(),
             pending: Some(self.buffer.len() + self.rx.len()),
-            error: if healthy {
-                None
-            } else {
-                Some("Redis PING failed".to_string())
-            },
+            error: stalled,
             ..Default::default()
         }
     }

--- a/src/endpoints/sqlx/dedup.rs
+++ b/src/endpoints/sqlx/dedup.rs
@@ -99,13 +99,33 @@ impl crate::middleware::deduplication::DedupStore for SqlDedupStore {
             positional_placeholder(&self.driver_name, 1),
             positional_placeholder(&self.driver_name, 2)
         );
-        if let Err(e) = sqlx::query(audited_sql(&sql))
+        match sqlx::query(audited_sql(&sql))
             .bind(expire_at)
-            .bind(id)
+            .bind(id.clone())
             .execute(&self.pool)
             .await
         {
-            warn!("Failed to mark dedup key processed in SQL: {}", e);
+            // The reserved row was reclaimed by cleanup in the meantime. Insert the marker
+            // instead of dropping it, so the key stays deduplicated (matching the Mongo
+            // store's upsert).
+            Ok(result) if result.rows_affected() == 0 => {
+                let ins = format!(
+                    "INSERT INTO {} (dedup_key, expire_at) VALUES ({}, {})",
+                    self.table,
+                    positional_placeholder(&self.driver_name, 1),
+                    positional_placeholder(&self.driver_name, 2)
+                );
+                if let Err(e) = sqlx::query(audited_sql(&ins))
+                    .bind(id)
+                    .bind(expire_at)
+                    .execute(&self.pool)
+                    .await
+                {
+                    warn!("Failed to insert dedup key marker in SQL: {}", e);
+                }
+            }
+            Ok(_) => {}
+            Err(e) => warn!("Failed to mark dedup key processed in SQL: {}", e),
         }
     }
 

--- a/src/endpoints/sqlx/mod.rs
+++ b/src/endpoints/sqlx/mod.rs
@@ -140,6 +140,21 @@ fn positional_placeholder(driver_name: &str, index: usize) -> String {
     }
 }
 
+/// True when `sql` still binds a value: an unrewritten `${…}` token, or a positional
+/// placeholder in any of the driver spellings (`?`, `$N`, `@pN`).
+fn binds_after_values(sql: &str) -> bool {
+    if sql.contains("${") {
+        return true;
+    }
+    let bytes = sql.as_bytes();
+    bytes.iter().enumerate().any(|(i, &b)| match b {
+        b'?' => true,
+        b'$' => bytes.get(i + 1).is_some_and(|c| c.is_ascii_digit()),
+        b'@' => bytes.get(i + 1) == Some(&b'p'),
+        _ => false,
+    })
+}
+
 /// Parse `${metadata:<key>}` / `${payload:<field>}` tokens out of an `insert_query`,
 /// rewriting each into a driver-appropriate positional placeholder assigned a running
 /// 1-based index in encounter order. Returns the rewritten query and the ordered
@@ -803,6 +818,16 @@ impl MessagePublisher for SqlxPublisher {
             None => "",
         };
 
+        // A token after the VALUES tuple (e.g. `ON CONFLICT … DO UPDATE SET v = ${payload:v}`)
+        // was already rewritten to a placeholder by `parse_insert_template`, numbered for the
+        // single-row query. The rebuild below renumbers only the row tuples, so the suffix
+        // would keep a stale index and the bind count would not line up. Single-row `send()`
+        // handles these correctly.
+        if binds_after_values(values_suffix) {
+            warn!("insert_query binds a value after the VALUES tuple. Falling back to iterative inserts.");
+            return self.send_batch_iterative(messages).await;
+        }
+
         // The `(payload)` single-column guard only applies to legacy mode; a
         // token-based query is already known-correct from `parse_insert_template`.
         if self.column_sources.is_empty() && !contains_payload_clause(base_query) {
@@ -906,10 +931,13 @@ impl SqlxPublisher {
             .copy_in_raw(&stmt)
             .await
             .map_err(classify_sql_error)?;
-        copier
-            .send(buf.as_bytes())
-            .await
-            .map_err(classify_sql_error)?;
+        if let Err(e) = copier.send(buf.as_bytes()).await {
+            // Tear the COPY down explicitly. `Drop` only buffers a CopyFail without
+            // awaiting the reply, so the connection could go back to the pool still in
+            // COPY-in state and poison the next query on it.
+            let _ = copier.abort("mq-bridge: COPY send failed").await;
+            return Err(classify_sql_error(e));
+        }
         copier.finish().await.map_err(classify_sql_error)?;
 
         trace!(count = messages.len(), table = %sink.table, "Bulk-copied batch to PostgreSQL");

--- a/src/endpoints/sqlx/mod.rs
+++ b/src/endpoints/sqlx/mod.rs
@@ -1901,7 +1901,8 @@ impl MessageConsumer for SqlxCursorReader {
             let cursor = cursor_col
                 .and_then(|(idx, kind)| extract_cursor_at(row, idx, kind))
                 .ok_or_else(|| {
-                    ConsumerError::Connection(anyhow!(
+                    // Schema-level, so re-polling fails identically: permanent, not a reconnect.
+                    ConsumerError::Permanent(anyhow!(
                         "cursor_column '{}' is missing or of a type the SQL `Any` driver cannot decode \
                          (only integer and text cursors are supported). CAST it to BIGINT/TEXT in a view, \
                          or point cursor_column at an integer or text column.",
@@ -1925,8 +1926,8 @@ impl MessageConsumer for SqlxCursorReader {
             if emit_len == 0 {
                 // A single cursor value fills the whole batch and more rows with that value exist
                 // beyond it. Advancing past the value would silently skip the remainder, so fail
-                // loudly instead of losing rows.
-                return Err(ConsumerError::Connection(anyhow!(
+                // loudly instead of losing rows. Permanent: re-polling returns the same page forever.
+                return Err(ConsumerError::Permanent(anyhow!(
                     "cursor_column '{}' has a group of equal values larger than batch_size ({}); \
                      cannot page without skipping rows. Increase batch_size above the size of the \
                      largest equal-value group.",

--- a/src/endpoints/sqlx/mod.rs
+++ b/src/endpoints/sqlx/mod.rs
@@ -1542,30 +1542,109 @@ fn quote_ident(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
 }
 
+/// Quote a SQL identifier for `driver_name`. MySQL/MariaDB use backticks; everyone else uses
+/// the SQL-standard double quote. Required for the checkpoint meta table: `last_value` is a
+/// reserved word in MySQL 8 (the `LAST_VALUE` window function), so unquoted DDL is a syntax
+/// error there — and a user-supplied table name may need quoting on any driver.
+fn quote_ident_for(driver_name: &str, name: &str) -> String {
+    match driver_name {
+        "MySQL" | "MariaDB" => format!("`{}`", name.replace('`', "``")),
+        _ => quote_ident(name),
+    }
+}
+
+/// MySQL/MariaDB `information_schema.columns.DATA_TYPE` values that the sqlx `Any` driver can
+/// map to an `AnyValue`. Mirrors sqlx-mysql's `MySqlTypeInfo -> AnyTypeInfo` conversion: the
+/// integer/float column types it names explicitly, plus everything `str`/`[u8]` declare
+/// compatible. Everything else — `decimal`, the whole date/time family, `json`, `bit`, `set`,
+/// `tinyint`, `mediumint`, and MariaDB's `uuid`/`inet6` — aborts row decoding, so it is cast.
+/// Unlisted types default to unsafe, which is the harmless direction (a needless cast).
+fn mysql_data_type_is_any_safe(data_type: &str) -> bool {
+    matches!(
+        data_type,
+        "smallint"
+            | "int"
+            | "integer"
+            | "bigint"
+            | "float"
+            | "double"
+            | "char"
+            | "varchar"
+            | "binary"
+            | "varbinary"
+            | "enum"
+            | "tinytext"
+            | "text"
+            | "mediumtext"
+            | "longtext"
+            | "tinyblob"
+            | "blob"
+            | "mediumblob"
+            | "longblob"
+    )
+}
+
+/// `$1::regclass` resolves the (optionally schema-qualified) table name against the current
+/// search_path. `pg_attribute.attname`/`pg_type.typname` are Postgres `name`-typed columns,
+/// which `Any` cannot decode directly (distinct from `text`), so cast them explicitly.
+const PG_COLUMN_TYPES_SQL: &str = "SELECT a.attname::text AS name, t.typname::text AS typname \
+     FROM pg_attribute a JOIN pg_type t ON t.oid = a.atttypid \
+     WHERE a.attrelid = $1::regclass AND a.attnum > 0 AND NOT a.attisdropped \
+     ORDER BY a.attnum";
+
+/// The bind is the schema part of a `db.table` name, empty for an unqualified one — in which
+/// case the connection's current database is used.
+const MYSQL_COLUMN_TYPES_SQL: &str = "SELECT COLUMN_NAME AS name, LOWER(DATA_TYPE) AS typname \
+     FROM information_schema.columns \
+     WHERE table_schema = COALESCE(NULLIF(?, ''), DATABASE()) AND table_name = ? \
+     ORDER BY ORDINAL_POSITION";
+
 /// Build the SELECT projection used in place of `*` for the cursor reader.
 ///
-/// On PostgreSQL the `Any` driver eagerly decodes every column when building a row and aborts
-/// the whole query on the first type it cannot map (e.g. `TIMESTAMPTZ`). We introspect the
-/// table's columns via the catalog and cast every `Any`-incompatible column to `text`, so the
-/// copy succeeds (unmappable values arrive as strings) instead of failing every read forever.
-/// Any introspection failure (or a non-PostgreSQL driver) falls back to `*`, preserving the
-/// previous behaviour.
+/// The `Any` driver eagerly decodes every column when building a row and aborts the whole
+/// query on the first type it cannot map (`TIMESTAMPTZ` on Postgres, `DECIMAL`/`TIMESTAMP` on
+/// MySQL). We introspect the table's columns and cast every `Any`-incompatible column to a
+/// string type, so the copy succeeds (unmappable values arrive as strings) instead of failing
+/// every read forever. Any introspection failure (or an unsupported driver, e.g. SQLite, whose
+/// dynamic typing needs no cast) falls back to `*`, preserving the previous behaviour.
 async fn build_cursor_projection(pool: &AnyPool, driver_name: &str, table: &str) -> String {
-    if driver_name != "PostgreSQL" {
-        return "*".to_string();
+    type SafeFn = fn(&str) -> bool;
+    type CastFn = fn(&str) -> String;
+
+    let (sql, binds, is_safe, cast): (&str, Vec<String>, SafeFn, CastFn) = match driver_name {
+        "PostgreSQL" => (
+            PG_COLUMN_TYPES_SQL,
+            vec![table.to_string()],
+            pg_typname_is_any_safe,
+            |ident| format!("{ident}::text AS {ident}"),
+        ),
+        "MySQL" | "MariaDB" => {
+            let (schema, name) = match table.split_once('.') {
+                Some((s, t)) => (
+                    s.trim_matches('`').to_string(),
+                    t.trim_matches('`').to_string(),
+                ),
+                None => (String::new(), table.trim_matches('`').to_string()),
+            };
+            (
+                MYSQL_COLUMN_TYPES_SQL,
+                vec![schema, name],
+                mysql_data_type_is_any_safe,
+                |ident| format!("CAST({ident} AS CHAR) AS {ident}"),
+            )
+        }
+        _ => return "*".to_string(),
+    };
+
+    let mut query = sqlx::query(sql);
+    for bind in binds {
+        query = query.bind(bind);
     }
-    // `$1::regclass` resolves the (optionally schema-qualified) table name against the current
-    // search_path. pg_attribute.attname/pg_type.typname are Postgres `name`-typed columns,
-    // which `Any` cannot decode directly (distinct from `text`), so cast them explicitly.
-    let sql = "SELECT a.attname::text AS name, t.typname::text AS typname \
-               FROM pg_attribute a JOIN pg_type t ON t.oid = a.atttypid \
-               WHERE a.attrelid = $1::regclass AND a.attnum > 0 AND NOT a.attisdropped \
-               ORDER BY a.attnum";
-    let rows = match sqlx::query(sql).bind(table).fetch_all(pool).await {
+    let rows = match query.fetch_all(pool).await {
         Ok(rows) if !rows.is_empty() => rows,
         Ok(_) => return "*".to_string(),
         Err(e) => {
-            warn!(table = %table, error = %e, "Could not introspect PostgreSQL columns; falling back to SELECT * (timestamptz/uuid/etc. columns may fail to decode)");
+            warn!(table = %table, error = %e, "Could not introspect {driver_name} columns; falling back to SELECT * (timestamp/decimal/uuid/etc. columns may fail to decode)");
             return "*".to_string();
         }
     };
@@ -1576,12 +1655,12 @@ async fn build_cursor_projection(pool: &AnyPool, driver_name: &str, table: &str)
             Err(_) => return "*".to_string(),
         };
         let typname: String = row.try_get("typname").unwrap_or_default();
-        let ident = quote_ident(&name);
-        if pg_typname_is_any_safe(&typname) {
+        let ident = quote_ident_for(driver_name, &name);
+        if is_safe(&typname) {
             parts.push(ident);
         } else {
-            // Cast to text so `Any` can decode it; keep the original column name via alias.
-            parts.push(format!("{ident}::text AS {ident}"));
+            // Cast to a string type so `Any` can decode it; keep the column name via alias.
+            parts.push(cast(&ident));
         }
     }
     parts.join(", ")
@@ -1607,15 +1686,26 @@ struct SqlTableCheckpointStore {
 }
 
 impl SqlTableCheckpointStore {
+    /// The meta table and its columns, quoted for this driver.
+    fn idents(&self) -> (String, String, String) {
+        let q = |n: &str| quote_ident_for(&self.driver_name, n);
+        (q(&self.meta_table), q("cursor_id"), q("last_value"))
+    }
+
     async fn ensure_table(&self) -> anyhow::Result<()> {
+        let (table, cursor_id, last_value) = self.idents();
         let sql = format!(
-            "CREATE TABLE IF NOT EXISTS {} (cursor_id VARCHAR(255) PRIMARY KEY, last_value TEXT)",
-            self.meta_table
+            "CREATE TABLE IF NOT EXISTS {table} ({cursor_id} VARCHAR(255) PRIMARY KEY, {last_value} TEXT)"
         );
         sqlx::query(audited_sql(&sql))
             .execute(&self.pool)
             .await
-            .with_context(|| format!("Failed to create meta table '{}'", self.meta_table))?;
+            // Inline the driver error rather than layering it as an anyhow source:
+            // the route logs only the top-level message, which hid e.g. MySQL's
+            // ERROR 1064 and made this near-undiagnosable.
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to create meta table '{}': {e}", self.meta_table)
+            })?;
         Ok(())
     }
 }
@@ -1623,9 +1713,9 @@ impl SqlTableCheckpointStore {
 #[async_trait]
 impl crate::checkpoint::CheckpointStore for SqlTableCheckpointStore {
     async fn load(&self) -> anyhow::Result<Option<String>> {
+        let (table, cursor_id, last_value) = self.idents();
         let sql = format!(
-            "SELECT last_value FROM {} WHERE cursor_id = {}",
-            self.meta_table,
+            "SELECT {last_value} FROM {table} WHERE {cursor_id} = {}",
             positional_placeholder(&self.driver_name, 1)
         );
         let row = sqlx::query(audited_sql(&sql))
@@ -1636,18 +1726,17 @@ impl crate::checkpoint::CheckpointStore for SqlTableCheckpointStore {
     }
 
     async fn save(&self, value: &str) -> anyhow::Result<()> {
+        let (table, cursor_id, last_value) = self.idents();
         let p1 = positional_placeholder(&self.driver_name, 1);
         let p2 = positional_placeholder(&self.driver_name, 2);
         let sql = match self.driver_name.as_str() {
             "MySQL" | "MariaDB" => format!(
-                "INSERT INTO {0} (cursor_id, last_value) VALUES ({1}, {2}) \
-                 ON DUPLICATE KEY UPDATE last_value = VALUES(last_value)",
-                self.meta_table, p1, p2
+                "INSERT INTO {table} ({cursor_id}, {last_value}) VALUES ({p1}, {p2}) \
+                 ON DUPLICATE KEY UPDATE {last_value} = VALUES({last_value})"
             ),
             _ => format!(
-                "INSERT INTO {0} (cursor_id, last_value) VALUES ({1}, {2}) \
-                 ON CONFLICT (cursor_id) DO UPDATE SET last_value = excluded.last_value",
-                self.meta_table, p1, p2
+                "INSERT INTO {table} ({cursor_id}, {last_value}) VALUES ({p1}, {p2}) \
+                 ON CONFLICT ({cursor_id}) DO UPDATE SET {last_value} = excluded.{last_value}"
             ),
         };
         sqlx::query(audited_sql(&sql))
@@ -1655,7 +1744,9 @@ impl crate::checkpoint::CheckpointStore for SqlTableCheckpointStore {
             .bind(value.to_string())
             .execute(&self.pool)
             .await
-            .with_context(|| format!("Failed to persist cursor to '{}'", self.meta_table))?;
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to persist cursor to '{}': {e}", self.meta_table)
+            })?;
         Ok(())
     }
 }

--- a/src/endpoints/sqlx/tests.rs
+++ b/src/endpoints/sqlx/tests.rs
@@ -158,6 +158,46 @@ async fn test_sqlx_cursor_reader_non_unique_column_no_loss() {
     );
 }
 
+// Regression: an equal-value group larger than batch_size can never be paged, so the error
+// must be Permanent. Classified as Connection it read as transient and the route re-polled
+// the same unpageable page forever, hanging `--drain` instead of exiting.
+#[tokio::test]
+async fn test_sqlx_cursor_oversized_equal_group_is_permanent() {
+    sqlx::any::install_default_drivers();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("wide.db");
+    let url = sqlite_url(&path);
+    drop(tokio::fs::File::create(&path).await.unwrap());
+    let pool = AnyPool::connect(&url).await.unwrap();
+    sqlx::query("CREATE TABLE events (id INTEGER PRIMARY KEY, ts INTEGER)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    // Four rows share ts=20, so a batch of 2 can never advance past the group.
+    for (id, ts) in [(1, 20), (2, 20), (3, 20), (4, 20), (5, 30)] {
+        sqlx::query("INSERT INTO events (id, ts) VALUES (?, ?)")
+            .bind(id)
+            .bind(ts)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    let config = SqlxConfig {
+        url: url.clone(),
+        table: "events".to_string(),
+        cursor_column: Some("ts".to_string()),
+        ..Default::default()
+    };
+    let mut reader = SqlxCursorReader::new(&config).await.unwrap();
+
+    let err = reader.receive_batch(2).await.expect_err("cannot page");
+    assert!(
+        matches!(err, ConsumerError::Permanent(_)),
+        "expected ConsumerError::Permanent, got {err:?}"
+    );
+}
+
 // Regression: a mid-batch Nack must make the nacked (and following) rows re-read by the
 // same running reader, not skipped until a restart. Rows 1..4 are read; row 3 is nacked,
 // so the next receive_batch on the same reader resumes at row 3.

--- a/src/endpoints/structural/reader.rs
+++ b/src/endpoints/structural/reader.rs
@@ -20,11 +20,22 @@ impl ReaderPublisher {
     }
 }
 
+/// How long a lifecycle hook waits for the consumer lock.
+///
+/// `send` holds the lock across `receive()`, which parks indefinitely on an idle source.
+/// An unbounded wait here would let that park block shutdown, so the hook is skipped
+/// rather than allowed to hang.
+const HOOK_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 #[async_trait]
 impl MessagePublisher for ReaderPublisher {
     fn on_connect_hook(&self) -> Option<BoxFuture<'_, anyhow::Result<()>>> {
         Some(Box::pin(async move {
-            let consumer = self.consumer.lock().await;
+            let Ok(consumer) = tokio::time::timeout(HOOK_LOCK_TIMEOUT, self.consumer.lock()).await
+            else {
+                tracing::warn!("ReaderPublisher: consumer busy, skipping connect hook");
+                return Ok(());
+            };
             if let Some(hook) = consumer.on_connect_hook() {
                 hook.await?;
             }
@@ -34,7 +45,11 @@ impl MessagePublisher for ReaderPublisher {
 
     fn on_disconnect_hook(&self) -> Option<BoxFuture<'_, anyhow::Result<()>>> {
         Some(Box::pin(async move {
-            let consumer = self.consumer.lock().await;
+            let Ok(consumer) = tokio::time::timeout(HOOK_LOCK_TIMEOUT, self.consumer.lock()).await
+            else {
+                tracing::warn!("ReaderPublisher: consumer busy, skipping disconnect hook");
+                return Ok(());
+            };
             if let Some(hook) = consumer.on_disconnect_hook() {
                 hook.await?;
             }

--- a/src/endpoints/structural/stream_buffer.rs
+++ b/src/endpoints/structural/stream_buffer.rs
@@ -57,7 +57,7 @@
 //!
 //! // Send the request with an explicit correlation id. If you omit this
 //! // metadata, the HTTP publisher uses format!("{:032x}", message.message_id).
-//! let mut request = CanonicalMessage::new(Payload::Text("hello".into()));
+//! let mut request = CanonicalMessage::new(Payload::Text("hello".into()), None);
 //! request.metadata.insert("correlation_id".into(), correlation_id.into());
 //! // create_publisher(&http).await?.send(request).await?;
 //!
@@ -130,6 +130,12 @@ use std::sync::{Arc, Mutex};
 use tracing::{trace, warn};
 
 const DEFAULT_CAPACITY: usize = 100;
+
+/// How long a publish waits on a full partition before giving up.
+///
+/// A partition whose reader never arrives (or went away without closing the channel) stays
+/// full forever, and an unbounded send would pin the publishing route on it.
+const SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[derive(Clone)]
 struct StreamPartition {
@@ -235,10 +241,17 @@ impl MessagePublisher for StreamBufferPublisher {
                 "stream_buffer partition is closed"
             )));
         }
-        partition.sender.send(vec![message]).await.map_err(|e| {
-            PublisherError::Retryable(anyhow!("Failed to send to stream_buffer: {}", e))
-        })?;
-        Ok(Sent::Ack)
+        match tokio::time::timeout(SEND_TIMEOUT, partition.sender.send(vec![message])).await {
+            Ok(Ok(())) => Ok(Sent::Ack),
+            Ok(Err(e)) => Err(PublisherError::Retryable(anyhow!(
+                "Failed to send to stream_buffer: {}",
+                e
+            ))),
+            Err(_) => Err(PublisherError::Retryable(anyhow!(
+                "stream_buffer partition '{}' is full and not being read",
+                correlation_id
+            ))),
+        }
     }
 
     async fn send_batch(
@@ -272,14 +285,22 @@ impl MessagePublisher for StreamBufferPublisher {
                 "stream_buffer partition is closed"
             )));
         }
-        partition
-            .sender
-            .send(std::mem::take(&mut messages))
-            .await
-            .map_err(|e| {
-                PublisherError::Retryable(anyhow!("Failed to send to stream_buffer: {}", e))
-            })?;
-        Ok(SentBatch::Ack)
+        match tokio::time::timeout(
+            SEND_TIMEOUT,
+            partition.sender.send(std::mem::take(&mut messages)),
+        )
+        .await
+        {
+            Ok(Ok(())) => Ok(SentBatch::Ack),
+            Ok(Err(e)) => Err(PublisherError::Retryable(anyhow!(
+                "Failed to send to stream_buffer: {}",
+                e
+            ))),
+            Err(_) => Err(PublisherError::Retryable(anyhow!(
+                "stream_buffer partition '{}' is full and not being read",
+                correlation_id
+            ))),
+        }
     }
 
     async fn status(&self) -> EndpointStatus {

--- a/src/endpoints/zeromq/omq.rs
+++ b/src/endpoints/zeromq/omq.rs
@@ -30,8 +30,16 @@ fn parse_endpoint(url: &str) -> anyhow::Result<Endpoint> {
 
 /// Collect every frame of a received omq `Message` into a plain `Vec<Bytes>` for
 /// the shared codec.
-fn message_frames(msg: &Message) -> Vec<bytes::Bytes> {
-    (0..msg.len()).filter_map(|i| msg.part_bytes(i)).collect()
+///
+/// Fails rather than skipping a missing part: `RawFramed` decoding is positional, so a
+/// silently dropped frame would shift every frame after it.
+fn message_frames(msg: &Message) -> anyhow::Result<Vec<bytes::Bytes>> {
+    (0..msg.len())
+        .map(|i| {
+            msg.part_bytes(i)
+                .ok_or_else(|| anyhow!("ZeroMQ message part {i} of {} is missing", msg.len()))
+        })
+        .collect()
 }
 
 /// Build an omq `Message` from codec frames (always at least one).
@@ -212,7 +220,8 @@ impl ZeroMqOmqConsumer {
             omq_tokio::Error::Closed => ConsumerError::EndOfStream,
             other => ConsumerError::Connection(anyhow!(other)),
         })?;
-        let msgs = codec::decode_frames(message_frames(&msg), self.is_sub, &self.format)
+        let frames = message_frames(&msg).map_err(|e| ConsumerError::Connection(anyhow!(e)))?;
+        let msgs = codec::decode_frames(frames, self.is_sub, &self.format)
             .map_err(|e| ConsumerError::Connection(anyhow!(e)))?;
         self.buffer.extend(msgs);
         Ok(())

--- a/src/endpoints/zeromq/zmq.rs
+++ b/src/endpoints/zeromq/zmq.rs
@@ -88,8 +88,28 @@ impl ZeroMqPublisher {
         let (tx, rx) = bounded::<PublisherJob>(buffer_size);
         let request_timeout =
             std::time::Duration::from_millis(config.request_timeout_ms.unwrap_or(30_000));
+        // Kept so a timed-out REQ socket can be rebuilt (see the timeout arm below).
+        let req_url = config.url.clone();
+        let req_bind = config.bind;
         tokio::spawn(async move {
+            let mut needs_req_reset = false;
             while let Ok(job) = rx.recv().await {
+                if needs_req_reset {
+                    needs_req_reset = false;
+                    let mut s = zeromq::ReqSocket::new();
+                    let connected = if req_bind {
+                        s.bind(&req_url).await.map(|_| ())
+                    } else {
+                        s.connect(&req_url).await
+                    };
+                    match connected {
+                        Ok(()) => socket = SenderSocket::Req(s),
+                        Err(e) => {
+                            tracing::error!(error = %e, "Failed to rebuild ZeroMQ REQ socket after a timeout; retrying on the next request");
+                            needs_req_reset = true;
+                        }
+                    }
+                }
                 match job {
                     PublisherJob::Send(msg, ack_tx) => match &mut socket {
                         SenderSocket::Push(s) => {
@@ -120,6 +140,11 @@ impl ZeroMqPublisher {
                                     let _ = reply_tx.send(Err(zeromq::ZmqError::Other(
                                         "ZeroMQ REQ/REP exchange timed out",
                                     )));
+                                    // REQ is strictly send/recv alternating. The cancelled
+                                    // recv leaves the socket expecting a reply that will
+                                    // never be read, so the next request would desync.
+                                    // Replace the socket instead of reusing it.
+                                    needs_req_reset = true;
                                 }
                             }
                         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,8 +45,13 @@ pub enum ConsumerError {
 
 impl From<anyhow::Error> for ConsumerError {
     fn from(err: anyhow::Error) -> Self {
-        // By default, we'll treat any generic error as a connection-level, retryable error.
-        ConsumerError::Connection(err)
+        // Preserve a classification the source already made — downgrading an existing
+        // `Permanent` to `Connection` would make the route retry something that cannot heal.
+        match err.downcast::<ConsumerError>() {
+            Ok(classified) => classified,
+            // Otherwise a generic error is connection-level, and therefore retryable.
+            Err(err) => ConsumerError::Connection(err),
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -84,6 +84,17 @@ mod tests {
     }
 
     #[test]
+    fn test_anyhow_conversion_preserves_existing_classification() {
+        let permanent = ConsumerError::from(anyhow::Error::new(ConsumerError::Permanent(
+            anyhow::anyhow!("decrypt failed"),
+        )));
+        assert!(matches!(permanent, ConsumerError::Permanent(_)));
+
+        let end = ConsumerError::from(anyhow::Error::new(ConsumerError::EndOfStream));
+        assert!(matches!(end, ConsumerError::EndOfStream));
+    }
+
+    #[test]
     fn test_consumer_error_display_messages() {
         assert_eq!(
             ConsumerError::Gap {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,10 @@ pub use publisher::Publisher;
 
 pub use endpoints::memory::get_or_create_channel;
 pub use publisher::{get_publisher, list_publishers, register_publisher, unregister_publisher};
-pub use route::{get_route, list_routes, register_endpoint, stop_route};
+pub use route::{
+    get_route, list_routes, register_endpoint, route_outcome, route_status, stop_route,
+    RouteOutcome,
+};
 
 // Re-export the underlying driver crate for each feature-gated endpoint, so
 // downstream code can depend on the exact same version mq-bridge builds against

--- a/src/middleware/deduplication.rs
+++ b/src/middleware/deduplication.rs
@@ -3,9 +3,11 @@
 //  Licensed under MIT License, see License file for more details
 //  git clone https://github.com/marcomq/mq-bridge
 use crate::models::DeduplicationMiddleware;
+use crate::support::interpolation::CompiledTemplate;
 use crate::traits::{
     BoxFuture, ConsumerError, MessageConsumer, MessageDisposition, Received, ReceivedBatch,
 };
+use crate::CanonicalMessage;
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use sled::Db;
@@ -329,6 +331,30 @@ pub(crate) fn hex_key(key: &[u8]) -> String {
 pub struct DeduplicationConsumer {
     inner: Box<dyn MessageConsumer>,
     store: Arc<dyn DedupStore>,
+    /// Compiled `key` template. `None` keys on `message_id`, which most sources
+    /// regenerate per read — so a re-read of the same source dedupes nothing.
+    key_template: Option<CompiledTemplate>,
+}
+
+/// The dedup key for a message: the rendered `key` template, or the raw `message_id`.
+///
+/// An unresolved selector renders empty, and an empty key would be shared by every message
+/// missing that field — silently dropping all but the first. Such a message falls back to
+/// `message_id` instead, so it is passed through rather than swallowed.
+fn dedup_key(template: Option<&CompiledTemplate>, msg: &CanonicalMessage) -> Vec<u8> {
+    match template {
+        Some(t) => match t.render(Some(msg)) {
+            key if key.is_empty() => {
+                warn!(
+                    message_id = %msg.message_id,
+                    "Deduplication `key` template resolved to nothing; keying on message_id for this message"
+                );
+                msg.message_id.to_be_bytes().to_vec()
+            }
+            key => key,
+        },
+        None => msg.message_id.to_be_bytes().to_vec(),
+    }
 }
 
 impl DeduplicationConsumer {
@@ -352,7 +378,17 @@ impl DeduplicationConsumer {
             }
         };
         let store = build_store(backend, config.ttl_seconds, route_name).await?;
-        Ok(Self { inner, store })
+        let key_template = config
+            .key
+            .as_deref()
+            .map(|k| CompiledTemplate::compile(k, None))
+            .transpose()
+            .context("invalid deduplication `key` template")?;
+        Ok(Self {
+            inner,
+            store,
+            key_template,
+        })
     }
 }
 
@@ -402,7 +438,7 @@ impl MessageConsumer for DeduplicationConsumer {
 
             self.store.maybe_cleanup(now);
 
-            let key = received.message.message_id.to_be_bytes();
+            let key = dedup_key(self.key_template.as_ref(), &received.message);
             if self.store.reserve(&key, now).await? {
                 info!(message_id = %format!("{:032x}", received.message.message_id), "Duplicate message detected and skipped");
                 if let Err(e) = (received.commit)(MessageDisposition::Ack).await {
@@ -412,7 +448,6 @@ impl MessageConsumer for DeduplicationConsumer {
             }
 
             let store = self.store.clone();
-            let message_id = received.message.message_id;
             let original_commit = received.commit;
 
             // Wrap commit to promote the reservation to "processed" state.
@@ -428,7 +463,7 @@ impl MessageConsumer for DeduplicationConsumer {
                             .duration_since(UNIX_EPOCH)
                             .unwrap_or_default()
                             .as_secs();
-                        store.mark_processed(&message_id.to_be_bytes(), now).await;
+                        store.mark_processed(&key, now).await;
                     }
                     Ok(())
                 }) as crate::traits::BoxFuture<'static, anyhow::Result<()>>
@@ -455,19 +490,29 @@ impl MessageConsumer for DeduplicationConsumer {
 
             self.store.maybe_cleanup(now);
 
+            // An empty inner batch is how a drained source signals `exit_on_empty`
+            // (see `traits::drain_gated`). Looping on it here would spin forever on
+            // an already-drained source, so pass it through untouched.
+            if messages.is_empty() {
+                return Ok(ReceivedBatch {
+                    messages,
+                    commit: inner_commit,
+                });
+            }
+
             let mut filtered_messages = Vec::with_capacity(messages.len());
             let mut kept_indices = Vec::with_capacity(messages.len());
 
+            let mut kept_keys: Vec<Vec<u8>> = Vec::with_capacity(messages.len());
+
             for (idx, msg) in messages.iter().enumerate() {
-                if self
-                    .store
-                    .reserve(&msg.message_id.to_be_bytes(), now)
-                    .await?
-                {
+                let key = dedup_key(self.key_template.as_ref(), msg);
+                if self.store.reserve(&key, now).await? {
                     info!(message_id = %format!("{:032x}", msg.message_id), "Duplicate message detected and skipped");
                 } else {
                     filtered_messages.push(msg.clone());
                     kept_indices.push(idx);
+                    kept_keys.push(key);
                 }
             }
 
@@ -477,21 +522,20 @@ impl MessageConsumer for DeduplicationConsumer {
             }
 
             let store = self.store.clone();
-            let kept_ids: Vec<u128> = filtered_messages.iter().map(|m| m.message_id).collect();
             let total_len = messages.len();
 
             let commit: crate::traits::BatchCommitFunc = Box::new(move |dispositions| {
                 let store = store.clone();
                 let inner_commit = inner_commit;
                 let kept_indices = kept_indices;
-                let kept_ids = kept_ids;
+                let kept_keys = kept_keys;
 
                 Box::pin(async move {
                     let mut full_dispositions = vec![MessageDisposition::Ack; total_len];
                     let mut acks = Vec::new();
                     for (i, disp) in dispositions.into_iter().enumerate() {
                         if matches!(disp, MessageDisposition::Ack | MessageDisposition::Reply(_)) {
-                            acks.push(kept_ids[i]);
+                            acks.push(kept_keys[i].clone());
                         }
                         full_dispositions[kept_indices[i]] = disp;
                     }
@@ -502,8 +546,8 @@ impl MessageConsumer for DeduplicationConsumer {
                         .duration_since(UNIX_EPOCH)
                         .unwrap_or_default()
                         .as_secs();
-                    for id in acks {
-                        store.mark_processed(&id.to_be_bytes(), now).await;
+                    for key in acks {
+                        store.mark_processed(&key, now).await;
                     }
                     Ok(())
                 }) as crate::traits::BoxFuture<'static, anyhow::Result<()>>
@@ -527,6 +571,7 @@ mod tests {
     use crate::endpoints::memory::MemoryConsumer;
     use crate::models::DeduplicationMiddleware;
     use crate::CanonicalMessage;
+    use std::time::Duration;
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -538,6 +583,7 @@ mod tests {
             store: None,
             sled_path: Some(db_path),
             ttl_seconds: 60,
+            key: None,
         };
 
         let mem_consumer = MemoryConsumer::new_local("dedup_topic", 10);
@@ -566,6 +612,133 @@ mod tests {
         let rec2 = dedup_consumer.receive().await.unwrap();
         assert_eq!(rec2.message.message_id, 101);
         let _ = (rec2.commit)(crate::traits::MessageDisposition::Ack).await;
+    }
+
+    /// Regression: an empty inner batch is how a drained source signals `exit_on_empty`.
+    /// The wrapper used to loop on it, so a route with `deduplication` on the input moved
+    /// everything and then hung `healthy: true` forever instead of completing.
+    #[tokio::test]
+    async fn empty_inner_batch_is_passed_through_for_drain() {
+        let dir = tempdir().unwrap();
+        let config = DeduplicationMiddleware {
+            store: None,
+            sled_path: Some(dir.path().join("dedup_drain").to_str().unwrap().to_string()),
+            ttl_seconds: 60,
+            key: None,
+        };
+
+        let mut mem_consumer = MemoryConsumer::new_local("dedup_drain_topic", 10);
+        mem_consumer.set_exit_on_empty(true);
+
+        let mut dedup_consumer =
+            DeduplicationConsumer::new(Box::new(mem_consumer), &config, "test_route")
+                .await
+                .unwrap();
+
+        let batch = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            dedup_consumer.receive_batch(16),
+        )
+        .await
+        .expect("receive_batch must return on a drained source, not loop forever")
+        .unwrap();
+
+        assert!(batch.messages.is_empty());
+    }
+
+    /// With a `key` template, dedup follows the payload, not `message_id` — which most
+    /// sources regenerate per read, so a re-read of the same data would dedupe nothing.
+    #[tokio::test]
+    async fn key_template_dedupes_on_payload_not_message_id() {
+        let dir = tempdir().unwrap();
+        let config = DeduplicationMiddleware {
+            store: None,
+            sled_path: Some(dir.path().join("dedup_key").to_str().unwrap().to_string()),
+            ttl_seconds: 60,
+            key: Some("${payload:order_id}".to_string()),
+        };
+
+        let mem_consumer = MemoryConsumer::new_local("dedup_key_topic", 10);
+        let channel = mem_consumer.channel();
+
+        // Same order_id, different message_ids: the second must be suppressed.
+        for id in [1u128, 2, 3] {
+            let body = if id == 3 {
+                br#"{"order_id":"B"}"#
+            } else {
+                br#"{"order_id":"A"}"#
+            };
+            channel
+                .send_message(CanonicalMessage::new(body.to_vec(), Some(id)))
+                .await
+                .unwrap();
+        }
+
+        let mut dedup_consumer =
+            DeduplicationConsumer::new(Box::new(mem_consumer), &config, "test_route")
+                .await
+                .unwrap();
+
+        // Timed out rather than awaited bare: a key that fails to resolve makes every
+        // message share one key, so the second `receive` would block forever.
+        macro_rules! recv {
+            () => {
+                tokio::time::timeout(Duration::from_secs(10), dedup_consumer.receive())
+                    .await
+                    .expect("receive timed out — the key template resolved to a constant")
+                    .unwrap()
+            };
+        }
+
+        let first = recv!();
+        assert_eq!(first.message.message_id, 1);
+        let _ = (first.commit)(crate::traits::MessageDisposition::Ack).await;
+
+        // message_id 2 carries order_id "A" again and is skipped internally.
+        let second = recv!();
+        assert_eq!(
+            second.message.message_id, 3,
+            "the second copy of order_id A must be suppressed by the key template"
+        );
+    }
+
+    /// A message missing the keyed field renders an empty key. Keying on that would make
+    /// every such message collide, so all but the first would vanish; they fall back to
+    /// `message_id` and are passed through instead.
+    #[tokio::test]
+    async fn messages_missing_the_keyed_field_are_not_collapsed() {
+        let dir = tempdir().unwrap();
+        let config = DeduplicationMiddleware {
+            store: None,
+            sled_path: Some(dir.path().join("dedup_miss").to_str().unwrap().to_string()),
+            ttl_seconds: 60,
+            key: Some("${payload:order_id}".to_string()),
+        };
+
+        let mem_consumer = MemoryConsumer::new_local("dedup_miss_topic", 10);
+        let channel = mem_consumer.channel();
+        for id in [1u128, 2, 3] {
+            channel
+                .send_message(CanonicalMessage::new(br#"{"other":1}"#.to_vec(), Some(id)))
+                .await
+                .unwrap();
+        }
+
+        let mut dedup_consumer =
+            DeduplicationConsumer::new(Box::new(mem_consumer), &config, "test_route")
+                .await
+                .unwrap();
+        dedup_consumer.set_exit_on_empty(true);
+
+        let batch = tokio::time::timeout(Duration::from_secs(10), dedup_consumer.receive_batch(16))
+            .await
+            .expect("receive_batch timed out")
+            .unwrap();
+        assert_eq!(
+            batch.messages.len(),
+            3,
+            "an unresolvable key must not collapse distinct messages into one"
+        );
     }
 
     #[test]

--- a/src/middleware/dlq.rs
+++ b/src/middleware/dlq.rs
@@ -12,9 +12,45 @@ use std::any::Any;
 use std::sync::Arc;
 use tracing::{debug, error, info};
 
+/// Metadata key holding why a message was dead-lettered.
+pub const DLQ_ERROR_KEY: &str = "mq_bridge.dlq.error";
+/// Metadata key holding the route that dead-lettered the message.
+pub const DLQ_ROUTE_KEY: &str = "mq_bridge.dlq.route";
+/// Metadata key holding when the message was dead-lettered, as Unix epoch milliseconds.
+pub const DLQ_TIMESTAMP_KEY: &str = "mq_bridge.dlq.timestamp_ms";
+
 pub struct DlqPublisher {
     inner: Box<dyn MessagePublisher>,
     dlq_publisher: Arc<dyn MessagePublisher>,
+    route_name: String,
+}
+
+/// Stamp the cause onto a message on its way to the DLQ. Without it a dead-lettered
+/// record is indistinguishable from a good one and carries no clue why it failed.
+fn tag_dlq_failure(message: &mut CanonicalMessage, error: &str, route_name: &str) {
+    tag_dlq_failure_at(message, error, route_name, &now_ms());
+}
+
+/// One batch is one dead-lettering event, so every message in it must carry the same
+/// timestamp — taking `now()` per message would spread them across the loop.
+fn tag_dlq_failure_at(message: &mut CanonicalMessage, error: &str, route_name: &str, now_ms: &str) {
+    message
+        .metadata
+        .insert(DLQ_ERROR_KEY.to_string(), error.to_string());
+    message
+        .metadata
+        .insert(DLQ_ROUTE_KEY.to_string(), route_name.to_string());
+    message
+        .metadata
+        .insert(DLQ_TIMESTAMP_KEY.to_string(), now_ms.to_string());
+}
+
+fn now_ms() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .to_string()
 }
 
 impl DlqPublisher {
@@ -31,6 +67,7 @@ impl DlqPublisher {
         Ok(Self {
             inner,
             dlq_publisher,
+            route_name: route_name.to_string(),
         })
     }
 }
@@ -104,6 +141,8 @@ impl MessagePublisher for DlqPublisher {
                     "Message send failed permanently, sending to DLQ: {}",
                     error_msg
                 );
+                let mut message = message;
+                tag_dlq_failure(&mut message, &error_msg, &self.route_name);
                 match self.dlq_publisher.send(message).await {
                     Ok(_) => Ok(Sent::Ack),
                     Err(dlq_error) => {
@@ -157,8 +196,16 @@ impl MessagePublisher for DlqPublisher {
                     non_retryable.len()
                 );
 
-                let messages_to_dlq: Vec<CanonicalMessage> =
-                    non_retryable.iter().map(|(msg, _)| msg.clone()).collect();
+                // Each message keeps its own failure, not a shared summary.
+                let now = now_ms();
+                let messages_to_dlq: Vec<CanonicalMessage> = non_retryable
+                    .iter()
+                    .map(|(msg, err)| {
+                        let mut msg = msg.clone();
+                        tag_dlq_failure_at(&mut msg, &err.to_string(), &self.route_name, &now);
+                        msg
+                    })
+                    .collect();
 
                 let final_failed = still_retryable;
 
@@ -221,6 +268,11 @@ impl MessagePublisher for DlqPublisher {
                 );
 
                 // We attempt to send the original batch to the DLQ.
+                let mut messages = messages;
+                let now = now_ms();
+                for msg in &mut messages {
+                    tag_dlq_failure_at(msg, &error_msg, &self.route_name, &now);
+                }
                 match self.dlq_publisher.send_batch(messages).await {
                     Ok(SentBatch::Ack) => {
                         debug!("Batch successfully sent to DLQ after complete primary failure.");
@@ -373,6 +425,7 @@ mod tests {
         let dlq_middleware = DlqPublisher {
             inner: Box::new(retry_publisher),
             dlq_publisher: Arc::new(dlq_target),
+            route_name: "test-route".to_string(),
         };
 
         let msg = CanonicalMessage::new(b"test".to_vec(), None);
@@ -418,6 +471,7 @@ mod tests {
         let dlq_middleware = DlqPublisher {
             inner: Box::new(retry_publisher),
             dlq_publisher: Arc::new(dlq_publisher),
+            route_name: "test-route".to_string(),
         };
 
         let msg_payload = b"failed_message";
@@ -434,6 +488,23 @@ mod tests {
         let dlq_msgs = dlq_channel.drain_messages();
         assert_eq!(dlq_msgs.len(), 1);
         assert_eq!(dlq_msgs[0].payload, msg_payload.as_slice());
+
+        // A dead-lettered record must say why it was dead-lettered.
+        let meta = &dlq_msgs[0].metadata;
+        assert!(
+            meta.get(DLQ_ERROR_KEY)
+                .is_some_and(|e| e.contains("Always fails")),
+            "DLQ record must carry the failure reason, got {meta:?}"
+        );
+        assert_eq!(
+            meta.get(DLQ_ROUTE_KEY).map(String::as_str),
+            Some("test-route")
+        );
+        assert!(
+            meta.get(DLQ_TIMESTAMP_KEY)
+                .is_some_and(|t| t.parse::<u64>().is_ok_and(|ms| ms > 0)),
+            "DLQ record must carry an epoch-ms timestamp, got {meta:?}"
+        );
     }
 
     #[derive(Clone)]
@@ -500,6 +571,7 @@ mod tests {
         let dlq_middleware = DlqPublisher {
             inner: Box::new(failing_target),
             dlq_publisher: Arc::new(dlq_target),
+            route_name: "test-route".to_string(),
         };
 
         let messages = vec![CanonicalMessage::from("1"), CanonicalMessage::from("2")];
@@ -522,6 +594,71 @@ mod tests {
         );
     }
 
+    /// One batch is one dead-lettering event: every message must carry the same
+    /// `timestamp_ms`, not one clock read per message.
+    #[tokio::test]
+    async fn batch_dlq_records_share_one_timestamp() {
+        struct CapturingPublisher {
+            seen: Arc<Mutex<Vec<CanonicalMessage>>>,
+        }
+
+        #[async_trait]
+        impl MessagePublisher for CapturingPublisher {
+            async fn send(&self, msg: CanonicalMessage) -> Result<Sent, PublisherError> {
+                self.seen.lock().unwrap().push(msg);
+                Ok(Sent::Ack)
+            }
+
+            async fn send_batch(
+                &self,
+                messages: Vec<CanonicalMessage>,
+            ) -> Result<SentBatch, PublisherError> {
+                self.seen.lock().unwrap().extend(messages);
+                Ok(SentBatch::Ack)
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let dlq_middleware = DlqPublisher {
+            inner: Box::new(MockFailingBatchPublisher {
+                calls: Arc::new(Mutex::new(0)),
+                fail_on_call: 1,
+                partial_fail: false,
+            }),
+            dlq_publisher: Arc::new(CapturingPublisher { seen: seen.clone() }),
+            route_name: "test-route".to_string(),
+        };
+
+        dlq_middleware
+            .send_batch(vec![
+                CanonicalMessage::from("1"),
+                CanonicalMessage::from("2"),
+                CanonicalMessage::from("3"),
+            ])
+            .await
+            .unwrap();
+
+        let stamps: Vec<Option<String>> = {
+            let seen = seen.lock().unwrap();
+            seen.iter()
+                .map(|m| m.metadata.get(DLQ_TIMESTAMP_KEY).cloned())
+                .collect()
+        };
+        assert_eq!(stamps.len(), 3, "every message must reach the DLQ");
+        assert!(
+            stamps.iter().all(Option::is_some),
+            "every DLQ record must be stamped, got {stamps:?}"
+        );
+        assert!(
+            stamps.iter().all(|s| *s == stamps[0]),
+            "one batch is one event, but got {stamps:?}"
+        );
+    }
+
     #[tokio::test]
     async fn test_dlq_send_batch_partial_failure() {
         let target_calls = Arc::new(Mutex::new(0));
@@ -539,6 +676,7 @@ mod tests {
         let dlq_middleware = DlqPublisher {
             inner: Box::new(failing_target),
             dlq_publisher: Arc::new(dlq_target),
+            route_name: "test-route".to_string(),
         };
 
         let messages = vec![CanonicalMessage::from("1"), CanonicalMessage::from("2")];
@@ -570,6 +708,7 @@ mod tests {
         let dlq_middleware = DlqPublisher {
             inner: Box::new(failing_target.clone()),
             dlq_publisher: Arc::new(failing_dlq),
+            route_name: "test-route".to_string(),
         };
         let result = dlq_middleware.send("test".into()).await;
         assert!(result.is_err());

--- a/src/middleware/encryption.rs
+++ b/src/middleware/encryption.rs
@@ -11,8 +11,8 @@
 use crate::models::EncryptionConfig;
 use crate::support::crypto::Crypto;
 use crate::traits::{
-    BoxFuture, ConsumerError, MessageConsumer, MessagePublisher, PublisherError, Received,
-    ReceivedBatch, Sent, SentBatch,
+    BoxFuture, ConsumerError, MessageConsumer, MessageDisposition, MessagePublisher,
+    PublisherError, Received, ReceivedBatch, Sent, SentBatch,
 };
 use crate::CanonicalMessage;
 use async_trait::async_trait;
@@ -145,12 +145,63 @@ impl MessageConsumer for EncryptionConsumer {
         Ok(received)
     }
 
+    /// A message that will not open is poison: returning the whole batch as an error drops
+    /// it uncommitted, so it is redelivered and fails again forever, taking every valid
+    /// message beside it down each time. Keep the valid ones and ack the rejected slots
+    /// instead, mirroring `TransformConsumer::receive_batch`.
     async fn receive_batch(&mut self, max_messages: usize) -> Result<ReceivedBatch, ConsumerError> {
-        let mut batch = self.inner.receive_batch(max_messages).await?;
-        for message in &mut batch.messages {
-            self.open_message(message)?;
+        loop {
+            let ReceivedBatch { messages, commit } = self.inner.receive_batch(max_messages).await?;
+            let original_len = messages.len();
+            let mut kept = Vec::with_capacity(original_len);
+            let mut kept_indices: Vec<usize> = Vec::with_capacity(original_len);
+
+            for (index, mut message) in messages.into_iter().enumerate() {
+                match self.open_message(&mut message) {
+                    Ok(()) => {
+                        kept_indices.push(index);
+                        kept.push(message);
+                    }
+                    Err(error) => tracing::error!(
+                        message_id = format_args!("{:032x}", message.message_id),
+                        "Rejecting message that failed to decrypt: {error}"
+                    ),
+                }
+            }
+
+            if kept.len() == original_len {
+                return Ok(ReceivedBatch {
+                    messages: kept,
+                    commit,
+                });
+            }
+
+            if kept.is_empty() {
+                // Every message was poison. Ack them so they are not redelivered forever,
+                // then fetch the next batch rather than surfacing an empty (idle-looking) one.
+                if original_len > 0 {
+                    commit(vec![MessageDisposition::Ack; original_len])
+                        .await
+                        .map_err(ConsumerError::Connection)?;
+                }
+                continue;
+            }
+
+            // Rejected slots are acked; the caller's dispositions go back at the indices
+            // they came from, keeping at-least-once intact for the surviving messages.
+            let remapped = Box::new(move |dispositions: Vec<MessageDisposition>| {
+                let mut full = vec![MessageDisposition::Ack; original_len];
+                for (slot, disposition) in kept_indices.into_iter().zip(dispositions) {
+                    full[slot] = disposition;
+                }
+                commit(full)
+            });
+
+            return Ok(ReceivedBatch {
+                messages: kept,
+                commit: remapped,
+            });
         }
-        Ok(batch)
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -191,8 +242,20 @@ mod tests {
         }
     }
 
+    /// Serves one batch then reports end-of-stream, and records the dispositions each
+    /// batch was committed with so the poison-message handling can be asserted.
     struct MockConsumer {
         messages: Option<Vec<CanonicalMessage>>,
+        committed: Arc<Mutex<Vec<Vec<MessageDisposition>>>>,
+    }
+
+    impl MockConsumer {
+        fn new(messages: Vec<CanonicalMessage>) -> Self {
+            Self {
+                messages: Some(messages),
+                committed: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
     }
 
     #[async_trait]
@@ -201,9 +264,16 @@ mod tests {
             &mut self,
             _max_messages: usize,
         ) -> Result<ReceivedBatch, ConsumerError> {
+            let Some(messages) = self.messages.take() else {
+                return Err(ConsumerError::EndOfStream);
+            };
+            let committed = self.committed.clone();
             Ok(ReceivedBatch {
-                messages: self.messages.take().expect("batch already consumed"),
-                commit: Box::new(|_| Box::pin(async { Ok(()) })),
+                messages,
+                commit: Box::new(move |dispositions| {
+                    committed.lock().unwrap().push(dispositions);
+                    Box::pin(async { Ok(()) })
+                }),
             })
         }
 
@@ -233,13 +303,8 @@ mod tests {
             Some("note")
         );
 
-        let mut consumer = EncryptionConsumer::new(
-            Box::new(MockConsumer {
-                messages: Some(wire),
-            }),
-            &config(),
-        )
-        .unwrap();
+        let mut consumer =
+            EncryptionConsumer::new(Box::new(MockConsumer::new(wire)), &config()).unwrap();
         let batch = consumer.receive_batch(10).await.unwrap();
         assert_eq!(batch.messages[0].payload.as_ref(), b"top secret");
         assert_eq!(
@@ -249,7 +314,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tampered_payload_fails_consume() {
+    async fn tampered_payload_is_dropped_not_redelivered() {
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let publisher = EncryptionPublisher::new(
+            Box::new(RecordingPublisher { sent: sent.clone() }),
+            &config(),
+        )
+        .unwrap();
+        publisher
+            .send_batch(vec![
+                CanonicalMessage::from("payload"),
+                CanonicalMessage::from("intact"),
+            ])
+            .await
+            .unwrap();
+
+        let mut wire = sent.lock().unwrap().clone();
+        let mut tampered = wire[0].payload.to_vec();
+        *tampered.last_mut().unwrap() ^= 1;
+        wire[0].payload = tampered.into();
+
+        let inner = MockConsumer::new(wire);
+        let committed = inner.committed.clone();
+        let mut consumer = EncryptionConsumer::new(Box::new(inner), &config()).unwrap();
+
+        // The poison message is dropped rather than failing the whole batch, so the
+        // intact message beside it is still delivered.
+        let batch = consumer.receive_batch(10).await.unwrap();
+        assert_eq!(batch.messages.len(), 1);
+        assert_eq!(batch.messages[0].payload.as_ref(), b"intact");
+
+        // Committing the surviving message acks the poison slot too, so it is not
+        // re-read indefinitely, and the caller's disposition lands at its own index.
+        (batch.commit)(vec![MessageDisposition::Nack])
+            .await
+            .unwrap();
+        let recorded = committed.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert!(matches!(
+            recorded[0].as_slice(),
+            [MessageDisposition::Ack, MessageDisposition::Nack]
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_all_poison_batch_is_acked_and_skipped() {
         let sent = Arc::new(Mutex::new(Vec::new()));
         let publisher = EncryptionPublisher::new(
             Box::new(RecordingPublisher { sent: sent.clone() }),
@@ -266,18 +375,18 @@ mod tests {
         *tampered.last_mut().unwrap() ^= 1;
         wire[0].payload = tampered.into();
 
-        let mut consumer = EncryptionConsumer::new(
-            Box::new(MockConsumer {
-                messages: Some(wire),
-            }),
-            &config(),
-        )
-        .unwrap();
-        // A tampered payload is a permanent failure, not a reconnectable one, so
-        // the poison message is not re-read indefinitely.
+        let inner = MockConsumer::new(wire);
+        let committed = inner.committed.clone();
+        let mut consumer = EncryptionConsumer::new(Box::new(inner), &config()).unwrap();
+
+        // Nothing survives, so the batch is acked and the next one is fetched — here
+        // the mock is exhausted, which surfaces as end-of-stream rather than a hang.
         assert!(matches!(
             consumer.receive_batch(10).await,
-            Err(ConsumerError::Permanent(_))
+            Err(ConsumerError::EndOfStream)
         ));
+        let recorded = committed.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert!(matches!(recorded[0].as_slice(), [MessageDisposition::Ack]));
     }
 }

--- a/src/middleware/retry.rs
+++ b/src/middleware/retry.rs
@@ -7,9 +7,28 @@ use std::any::Any;
 use std::time::Duration;
 use tracing::warn;
 
+/// Metadata key carrying the 1-based delivery attempt, present only on **re**-deliveries
+/// (attempt ≥ 2). Everything downstream of `retry` — including a handler, which `retry`
+/// re-invokes once per attempt when it wraps one — is otherwise unable to tell a retry
+/// from a first delivery, which makes per-message counting scale with `max_attempts`.
+pub const RETRY_ATTEMPT_KEY: &str = "mq_bridge.retry.attempt";
+
 pub struct RetryPublisher {
     inner: Box<dyn MessagePublisher>,
     config: RetryMiddleware,
+}
+
+/// Stamp the attempt number on a redelivery. Attempt 1 clears the key rather than
+/// leaving it, so "no key" reliably means "first try" even for a message that arrived
+/// already carrying one.
+fn tag_attempt(message: &mut CanonicalMessage, attempt: usize) {
+    if attempt > 1 {
+        message
+            .metadata
+            .insert(RETRY_ATTEMPT_KEY.to_string(), attempt.to_string());
+    } else {
+        message.metadata.remove(RETRY_ATTEMPT_KEY);
+    }
 }
 
 impl RetryPublisher {
@@ -17,9 +36,10 @@ impl RetryPublisher {
         Self { inner, config }
     }
 
+    /// `operation` receives the 1-based attempt number so it can mark redeliveries.
     async fn retry_op<F, Fut, T>(&self, operation: F) -> Result<T, PublisherError>
     where
-        F: Fn() -> Fut,
+        F: Fn(usize) -> Fut,
         Fut: std::future::Future<Output = Result<T, PublisherError>>,
     {
         let mut attempt = 0;
@@ -27,7 +47,7 @@ impl RetryPublisher {
 
         loop {
             attempt += 1;
-            match operation().await {
+            match operation(attempt).await {
                 Ok(val) => return Ok(val),
                 Err(e @ PublisherError::NonRetryable(_)) => return Err(e), // Don't retry non-retryable errors
                 Err(e @ PublisherError::Connection(_)) => return Err(e), // Propagate connection errors
@@ -69,8 +89,9 @@ impl MessagePublisher for RetryPublisher {
     }
 
     async fn send(&self, message: CanonicalMessage) -> Result<Sent, PublisherError> {
-        self.retry_op(|| {
-            let msg = message.clone();
+        self.retry_op(|attempt| {
+            let mut msg = message.clone();
+            tag_attempt(&mut msg, attempt);
             async { self.inner.send(msg).await }
         })
         .await
@@ -90,7 +111,11 @@ impl MessagePublisher for RetryPublisher {
 
         loop {
             attempt += 1;
-            match self.inner.send_batch(current_messages.clone()).await {
+            let mut outgoing = current_messages.clone();
+            for msg in &mut outgoing {
+                tag_attempt(msg, attempt);
+            }
+            match self.inner.send_batch(outgoing).await {
                 Ok(SentBatch::Ack) => {
                     return if all_responses.is_empty() && all_failed.is_empty() {
                         Ok(SentBatch::Ack)
@@ -246,6 +271,66 @@ mod tests {
         let result = retry_publisher.send(msg).await;
         assert!(result.is_ok());
         assert_eq!(*attempts.lock().unwrap(), 3);
+    }
+
+    /// A redelivery must be distinguishable from a first delivery, so anything downstream
+    /// (a handler, or a caller counting messages) does not count one message N times.
+    #[tokio::test]
+    async fn redeliveries_carry_an_attempt_marker() {
+        #[derive(Clone)]
+        struct RecordingPublisher {
+            seen: Arc<Mutex<Vec<Option<String>>>>,
+            succeed_after: usize,
+        }
+
+        #[async_trait]
+        impl MessagePublisher for RecordingPublisher {
+            async fn send(&self, msg: CanonicalMessage) -> Result<Sent, PublisherError> {
+                let mut seen = self.seen.lock().unwrap();
+                seen.push(msg.metadata.get(RETRY_ATTEMPT_KEY).cloned());
+                if seen.len() > self.succeed_after {
+                    Ok(Sent::Ack)
+                } else {
+                    Err(anyhow!("Simulated error").into())
+                }
+            }
+
+            async fn send_batch(
+                &self,
+                _messages: Vec<CanonicalMessage>,
+            ) -> Result<SentBatch, PublisherError> {
+                Ok(SentBatch::Ack)
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let mock = RecordingPublisher {
+            seen: seen.clone(),
+            succeed_after: 2,
+        };
+        let config = RetryMiddleware {
+            max_attempts: 5,
+            initial_interval_ms: 1,
+            max_interval_ms: 10,
+            multiplier: 1.0,
+        };
+
+        let retry_publisher = RetryPublisher::new(Box::new(mock), config);
+        retry_publisher
+            .send(CanonicalMessage::new(vec![], None))
+            .await
+            .unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(
+            *seen,
+            vec![None, Some("2".to_string()), Some("3".to_string())],
+            "attempt 1 must be unmarked; every redelivery must carry its attempt number"
+        );
     }
 
     #[tokio::test]

--- a/src/middleware/transform/schema.rs
+++ b/src/middleware/transform/schema.rs
@@ -192,11 +192,9 @@ impl CompiledSchema {
                 return Err(TransformError::new(
                     render_path(crumbs),
                     ErrorKind::Enum,
-                    format!(
-                        "value {} is not one of {}",
-                        value,
-                        Value::Array(allowed.clone())
-                    ),
+                    // The rejected value is payload data; report only the allowed set,
+                    // matching the type-only reporting in `coerce()`.
+                    format!("value is not one of {}", Value::Array(allowed.clone())),
                 ));
             }
         }

--- a/src/models.rs
+++ b/src/models.rs
@@ -3206,7 +3206,7 @@ pub struct PostgresCdcConfig {
     /// Missing ones are added to an existing publication (never removed). Empty = `FOR ALL TABLES` (needs superuser).
     #[serde(default)]
     pub publication_tables: Vec<String>,
-    /// Use a temporary slot (dropped on disconnect). Not restart-safe; default is a permanent slot.
+    /// Ephemeral run: drop the slot when the route stops. Not restart-safe; a hard crash leaks it.
     #[serde(default)]
     pub temporary_slot: bool,
     /// Checkpoint key for persisting the confirmed LSN across restarts (optional; the slot is authoritative).

--- a/src/models.rs
+++ b/src/models.rs
@@ -314,6 +314,7 @@ fn is_known_endpoint_name(name: &str) -> bool {
 /// Represents a connection point for messages, which can be a source (input) or a sink (output).
 #[derive(Serialize, Clone, Default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(transform = endpoint_schema_transform))]
 #[serde(deny_unknown_fields)]
 pub struct Endpoint {
     /// (Optional) A list of middlewares to apply to the endpoint.
@@ -1577,10 +1578,10 @@ pub struct FileConfig {
     /// The format for writing messages to the file (Publisher) or interpreting them (Consumer). Defaults to `normal`.
     #[serde(default)]
     pub format: FileFormat,
-    /// Per-batch compression (`none`, `gzip`, `lz4`, `zstd`). Requires the `compression` feature; consume mode only.
+    /// Per-batch compression (`none`, `gzip`, `lz4`, `zstd`). Requires the `compression` feature. Publishers: always. Consumers: must match, and only the default `consume` mode reads it.
     #[serde(default)]
     pub compression: Compression,
-    /// At-rest AEAD encryption applied after compression. Requires the `encryption` feature; consume mode only.
+    /// At-rest AEAD encryption applied after compression. Requires the `encryption` feature. Publishers: always. Consumers: must match, and only the default `consume` mode reads it.
     #[serde(default)]
     pub encryption: Option<EncryptionConfig>,
 }
@@ -2025,6 +2026,31 @@ fn memory_config_schema_transform(schema: &mut schemars::Schema) {
             { "required": ["url"] }
         ]),
     );
+}
+
+/// `null` is a unit variant, so schemars emits it as the bare string `"null"` — which can
+/// never validate inside `Endpoint`'s object schema. Flattened, it serialises as
+/// `{ "null": null }`; rewrite the branch to that object form.
+#[cfg(feature = "schema")]
+fn endpoint_schema_transform(schema: &mut schemars::Schema) {
+    let Some(one_of) = schema
+        .as_object_mut()
+        .and_then(|schema_obj| schema_obj.get_mut("oneOf"))
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+
+    for branch in one_of.iter_mut() {
+        if branch.get("const") == Some(&serde_json::Value::String("null".to_string())) {
+            *branch = serde_json::json!({
+                "type": "object",
+                "format": "structural_endpoint",
+                "properties": { "null": { "type": "null" } },
+                "required": ["null"]
+            });
+        }
+    }
 }
 
 #[cfg(feature = "schema")]

--- a/src/models.rs
+++ b/src/models.rs
@@ -918,6 +918,9 @@ pub struct DeduplicationMiddleware {
     pub sled_path: Option<String>,
     /// Time-to-live for deduplication entries in seconds.
     pub ttl_seconds: u64,
+    /// Dedup key template, e.g. `${payload:order_id}`. Defaults to `message_id`.
+    #[serde(default)]
+    pub key: Option<String>,
 }
 
 /// Metrics middleware configuration.

--- a/src/route.rs
+++ b/src/route.rs
@@ -1644,6 +1644,28 @@ pub fn list_routes() -> Vec<String> {
     Route::list()
 }
 
+/// Returns why a deployed route terminated, or `None` while it is still running
+/// (or if nothing is deployed under `name`).
+///
+/// [`Route::deploy`] keeps its [`RouteHandle`] private, so this is how a caller
+/// that deployed by name — the language bindings, a supervisor — learns that a
+/// drain-then-exit route finished on its own rather than waiting on a `stop()`
+/// that never comes.
+pub fn route_outcome(name: &str) -> Option<RouteOutcome> {
+    let registry = ROUTE_REGISTRY.get()?;
+    let map = recover_read_lock(registry, "route_registry");
+    map.get(name)?.handle.outcome()
+}
+
+/// Returns the connection health of a deployed route, or `None` if nothing is
+/// deployed under `name`. Pairs with [`route_outcome`]: after a
+/// [`RouteOutcome::Failed`], `error` holds the cause.
+pub fn route_status(name: &str) -> Option<EndpointStatus> {
+    let registry = ROUTE_REGISTRY.get()?;
+    let map = recover_read_lock(registry, "route_registry");
+    Some(map.get(name)?.handle.status())
+}
+
 pub async fn stop_route(name: &str) -> bool {
     Route::stop(name).await
 }

--- a/src/route.rs
+++ b/src/route.rs
@@ -863,9 +863,11 @@ impl Route {
                 handle.abort();
                 // The startup failure itself stays inside the reconnect loop, so
                 // surface the cause it recorded rather than a bare timeout.
+                // "connecting" is the initial marker, not a recorded failure.
                 let cause = recover_read_lock(&status, "route_handle_status")
                     .error
                     .clone()
+                    .filter(|e| e != "connecting")
                     .map(|e| format!(": {e}"))
                     .unwrap_or_default();
                 Err(anyhow::anyhow!(

--- a/src/route.rs
+++ b/src/route.rs
@@ -861,10 +861,18 @@ impl Route {
             }),
             _ => {
                 handle.abort();
+                // The startup failure itself stays inside the reconnect loop, so
+                // surface the cause it recorded rather than a bare timeout.
+                let cause = recover_read_lock(&status, "route_handle_status")
+                    .error
+                    .clone()
+                    .map(|e| format!(": {e}"))
+                    .unwrap_or_default();
                 Err(anyhow::anyhow!(
-                    "Route '{}' failed to start within {}ms or encountered an error",
+                    "Route '{}' failed to start within {}ms or encountered an error{}",
                     name_str,
-                    startup_timeout.as_millis()
+                    startup_timeout.as_millis(),
+                    cause
                 ))
             }
         }

--- a/src/support/compression.rs
+++ b/src/support/compression.rs
@@ -100,7 +100,7 @@ pub(crate) fn decompress_all(
             if out.len() as u64 > limit {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    format!("decompressed data exceeds max_object_bytes ({limit})"),
+                    format!("decompressed data exceeds the decode limit of {limit} bytes"),
                 ));
             }
         }

--- a/src/support/connection_registry.rs
+++ b/src/support/connection_registry.rs
@@ -25,9 +25,9 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 
-/// `(tag, identity)` where `identity` is the full structural connection identity
-/// (see [`connection_identity`]). Using the complete identity rather than a hash
-/// means two distinct connections can never collide onto the same cache entry.
+/// `(tag, identity)` where `identity` is the SHA-256 hex digest of the full structural
+/// connection identity (see [`connection_identity`]). Two distinct connections sharing a
+/// cache entry would therefore require a SHA-256 collision.
 type Key = (&'static str, String);
 
 static REGISTRY: OnceLock<RwLock<HashMap<Key, Weak<dyn Any + Send + Sync>>>> = OnceLock::new();

--- a/src/support/crypto.rs
+++ b/src/support/crypto.rs
@@ -26,11 +26,9 @@ use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::XChaCha20Poly1305;
 use std::collections::HashMap;
 
-const ENVELOPE_VERSION: u8 = 1;
-const CIPHER_XCHACHA: u8 = 0;
-const CIPHER_AES_GCM: u8 = 1;
-const XCHACHA_NONCE_LEN: usize = 24;
-const AES_GCM_NONCE_LEN: usize = 12;
+use super::crypto_envelope::{
+    AES_GCM_NONCE_LEN, CIPHER_AES_GCM, CIPHER_XCHACHA, ENVELOPE_VERSION, XCHACHA_NONCE_LEN,
+};
 
 /// A ready-to-use AEAD engine built from an [`EncryptionConfig`]: the active
 /// seal key plus any extra decrypt-only keys (rotation).

--- a/src/support/crypto_envelope.rs
+++ b/src/support/crypto_envelope.rs
@@ -1,0 +1,17 @@
+//  mq-bridge
+//  © Copyright 2026, by Marco Mengelkoch
+//  Licensed under MIT License, see License file for more details
+//  git clone https://github.com/marcomq/mq-bridge
+
+//! Wire-format constants of the crypto envelope. Kept out of [`super::crypto`]
+//! so at-rest detection still works without the `encryption` feature.
+
+pub(crate) const ENVELOPE_VERSION: u8 = 1;
+pub(crate) const CIPHER_XCHACHA: u8 = 0;
+pub(crate) const CIPHER_AES_GCM: u8 = 1;
+#[cfg(feature = "encryption")]
+pub(crate) const XCHACHA_NONCE_LEN: usize = 24;
+pub(crate) const AES_GCM_NONCE_LEN: usize = 12;
+
+/// Header (`version`, `cipher`, `key_id_len`) + shortest key id + shortest nonce.
+pub(crate) const MIN_ENVELOPE_LEN: usize = 3 + 1 + AES_GCM_NONCE_LEN;

--- a/src/support/mod.rs
+++ b/src/support/mod.rs
@@ -12,4 +12,5 @@ pub(crate) mod compression;
 pub mod connection_registry;
 #[cfg(feature = "encryption")]
 pub mod crypto;
+pub(crate) mod crypto_envelope;
 pub mod interpolation;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -195,6 +195,12 @@ pub(crate) fn drain_idle_timeout() -> std::time::Duration {
 /// Awaits `fut`, but in drain mode gives up after [`drain_idle_timeout`], returning
 /// `None` so a blocking consumer can surface an empty batch instead of hanging.
 /// Outside drain mode it simply awaits, preserving the event-driven fast path.
+///
+/// `fut` **must be cancel safe**: on expiry the timeout drops it mid-poll. A future that
+/// has already taken a message off the transport at that point loses it silently — and
+/// drain reports completion, so nothing retries it. Channel `recv`/`recv_many`,
+/// `Stream::next`, and the length-delimited IPC `recv_batch` all qualify; a hand-rolled
+/// `read_exact` pair does not.
 pub(crate) async fn drain_gated<F: std::future::Future>(
     exit_on_empty: bool,
     fut: F,

--- a/tests/integration/mariadb.rs
+++ b/tests/integration/mariadb.rs
@@ -91,6 +91,22 @@ where
     .await;
 }
 
+pub async fn test_mariadb_cursor_unmappable_types() {
+    setup_logging();
+    run_test_with_docker(DOCKER_COMPOSE_FILE, || async {
+        super::mysql::assert_cursor_reads_unmappable_types(DATABASE_URL, "mariadb-types").await;
+    })
+    .await;
+}
+
+pub async fn test_mariadb_checkpoint_table() {
+    setup_logging();
+    run_test_with_docker(DOCKER_COMPOSE_FILE, || async {
+        super::mysql::assert_sql_checkpoint_round_trip(DATABASE_URL, "mariadb").await;
+    })
+    .await;
+}
+
 pub async fn test_mariadb_chaos() {
     setup_logging();
     run_test_with_docker_controller(DOCKER_COMPOSE_FILE, |controller| async move {

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -53,3 +53,35 @@ pub mod memory;
 #[cfg(feature = "grpc")]
 pub mod grpc_tls;
 pub mod route;
+
+/// Assert that running `route` once fails with a `ConsumerError::Permanent`.
+///
+/// This targets the classification itself, which is what decides the route's fate:
+/// `route.rs` breaks out of the reconnect loop only for `Permanent`, so anything else spins
+/// on the reconnect interval forever. `run_until_err` is used rather than `run` because a
+/// permanent failure *during startup* reaches the caller of `run` as the same generic
+/// "failed to start" error as a timeout — the very ambiguity that hid these diagnoses.
+#[allow(dead_code)]
+pub async fn assert_permanent_consumer_error(
+    route: mq_bridge::Route,
+    route_name: &str,
+    label: &str,
+) {
+    use mq_bridge::traits::ConsumerError;
+
+    let err = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        route.run_until_err(route_name, None, None),
+    )
+    .await
+    .unwrap_or_else(|_| panic!("'{label}': route neither completed nor failed"))
+    .expect_err("must fail");
+
+    assert!(
+        matches!(
+            err.downcast_ref::<ConsumerError>(),
+            Some(ConsumerError::Permanent(_))
+        ),
+        "'{label}': must be a permanent error so the route stops; got: {err:#}"
+    );
+}

--- a/tests/integration/mongodb.rs
+++ b/tests/integration/mongodb.rs
@@ -450,6 +450,45 @@ pub async fn test_mongodb_cdc_latency() {
     .await;
 }
 
+/// Regression: a change stream that sits idle past the idle resume-token refresh interval
+/// (10s) must keep streaming. The idle branch used to poll with a cancellable `StreamExt::next`
+/// and then read `resume_token()`, which panics unless the driver's stream state is `Idle` —
+/// the cancelled poll left it non-`Idle`, aborting the process on every idle CDC route.
+pub async fn test_mongodb_cdc_survives_idle_resume_refresh() {
+    setup_logging();
+    run_test_with_docker(
+        "tests/integration/docker-compose/mongodb-replica.yml",
+        || async {
+            let collection = format!("cdc_idle_{}", fast_uuid_v7::gen_id());
+            let mut reader = MongoDbChangeStreamReader::new(&cdc_reader_cfg(&collection), false)
+                .await
+                .expect("create CDC reader");
+
+            let client = mongodb::Client::with_uri_str(CDC_URL).await.unwrap();
+            let coll = client
+                .database(CDC_DB)
+                .collection::<mongodb::bson::Document>(&collection);
+
+            // Idle well past IDLE_RESUME_REFRESH so the refresh branch runs at least twice,
+            // then write: the stream must still deliver the change.
+            let writer = tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(25)).await;
+                coll.insert_one(mongodb::bson::doc! { "id": 1i64, "name": "after-idle" })
+                    .await
+                    .expect("insert after idle");
+            });
+
+            let seen = drain_cdc(&mut reader, 1).await;
+            assert!(
+                seen >= 1,
+                "change after a long idle period must be delivered"
+            );
+            writer.await.expect("writer task panicked");
+        },
+    )
+    .await;
+}
+
 async fn run_mongodb_direct_perf_test_impl(
     compose_file: &str,
     url: &str,

--- a/tests/integration/mongodb.rs
+++ b/tests/integration/mongodb.rs
@@ -311,7 +311,7 @@ async fn drain_cdc(reader: &mut MongoDbChangeStreamReader, want: usize) -> usize
     let mut got = 0usize;
     while got < want {
         let batch = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
+            std::time::Duration::from_secs(60),
             reader.receive_batch(1024),
         )
         .await

--- a/tests/integration/mysql.rs
+++ b/tests/integration/mysql.rs
@@ -69,6 +69,141 @@ pub async fn test_mysql_performance_pipeline() {
     .await;
 }
 
+/// Creates the checkpoint meta table and round-trips a cursor value through it.
+///
+/// Shared with the MariaDB suite. `last_value` is a reserved word on MySQL 8 (the
+/// `LAST_VALUE` window function), so unquoted DDL fails there with ERROR 1064 — this is
+/// the regression guard for the per-driver identifier quoting.
+pub async fn assert_sql_checkpoint_round_trip(database_url: &str, source_name: &str) {
+    let cursor_id = format!("cp-{}", fast_uuid_v7::gen_id());
+    let backend = mq_bridge::checkpoint::parse_checkpoint_store(database_url)
+        .expect("parse sqlx checkpoint_store");
+
+    let store =
+        mq_bridge::checkpoint::build_external_store(backend.clone(), source_name, &cursor_id)
+            .await
+            .expect("create checkpoint meta table");
+    assert_eq!(store.load().await.unwrap(), None, "fresh cursor is empty");
+    store.save("42").await.expect("save cursor");
+    assert_eq!(store.load().await.unwrap(), Some("42".to_string()));
+    store.save("99").await.expect("overwrite cursor");
+
+    // A freshly built store for the same cursor sees the persisted value.
+    let reopened = mq_bridge::checkpoint::build_external_store(backend, source_name, &cursor_id)
+        .await
+        .expect("rebuild checkpoint store");
+    assert_eq!(reopened.load().await.unwrap(), Some("99".to_string()));
+}
+
+/// Regression: a source table with types the sqlx `Any` driver cannot map — `DECIMAL`
+/// (`NewDecimal`), `TIMESTAMP`/`DATETIME`, `JSON`, `TINYINT` — must be readable by the cursor
+/// reader instead of failing every read forever. The `::text` auto-cast originally shipped for
+/// PostgreSQL only; this is the MySQL/MariaDB half (`CAST(col AS CHAR)`).
+///
+/// Shared with the MariaDB suite.
+pub async fn assert_cursor_reads_unmappable_types(database_url: &str, cursor_id: &str) {
+    use mq_bridge::traits::MessageConsumer;
+    use sqlx::AnyPool;
+
+    sqlx::any::install_default_drivers();
+    let pool = AnyPool::connect(database_url).await.unwrap();
+    sqlx::query("DROP TABLE IF EXISTS typed_events")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE typed_events (\
+            id BIGINT PRIMARY KEY, \
+            name VARCHAR(64), \
+            amount DECIMAL(10,2), \
+            active TINYINT(1), \
+            ratio DOUBLE, \
+            payload JSON, \
+            created_at TIMESTAMP)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    // Insert via literal SQL: binding DECIMAL/TIMESTAMP/JSON through `Any` is itself unsupported.
+    for i in 1..=3 {
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "INSERT INTO typed_events VALUES ({i}, 'row{i}', {i}.50, 1, {i}.25, \
+             '{{\"k\": {i}}}', TIMESTAMP '2024-01-0{i} 12:00:00')"
+        )))
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    let config = mq_bridge::models::SqlxConfig {
+        url: database_url.to_string(),
+        table: "typed_events".to_string(),
+        cursor_column: Some("id".to_string()),
+        cursor_id: Some(cursor_id.to_string()),
+        ..Default::default()
+    };
+
+    let mut reader = mq_bridge::endpoints::sqlx::SqlxCursorReader::new(&config)
+        .await
+        .unwrap();
+    let batch = reader.receive_batch(10).await.unwrap();
+    assert_eq!(batch.messages.len(), 3, "all 3 rows must be read");
+
+    let rows: Vec<serde_json::Value> = batch
+        .messages
+        .iter()
+        .map(|m| serde_json::from_slice(&m.payload).unwrap())
+        .collect();
+
+    // The unmappable columns arrive as (cast-to-CHAR) strings, not null.
+    let created = rows[0].get("created_at").and_then(|v| v.as_str());
+    assert!(
+        created.is_some_and(|s| s.starts_with("2024-01-01")),
+        "created_at should be a timestamp string, got {:?}",
+        rows[0].get("created_at")
+    );
+    assert_eq!(
+        rows[0].get("amount").and_then(|v| v.as_str()),
+        Some("1.50"),
+        "decimal -> string"
+    );
+    assert!(
+        rows[0].get("payload").unwrap().is_string(),
+        "json -> string"
+    );
+    assert!(
+        rows[0].get("active").unwrap().is_string(),
+        "tinyint is not Any-mappable either -> string"
+    );
+    // Natively mappable types keep their JSON types.
+    assert!(rows[0].get("id").unwrap().is_i64(), "bigint stays numeric");
+    assert!(rows[0].get("ratio").unwrap().is_f64(), "double stays f64");
+    assert!(
+        rows[0].get("name").unwrap().is_string(),
+        "varchar stays str"
+    );
+
+    (batch.commit)(vec![mq_bridge::traits::MessageDisposition::Ack; 3])
+        .await
+        .unwrap();
+}
+
+pub async fn test_mysql_cursor_unmappable_types() {
+    setup_logging();
+    run_test_with_docker(DOCKER_COMPOSE_FILE, || async {
+        assert_cursor_reads_unmappable_types(DATABASE_URL, "mysql-types").await;
+    })
+    .await;
+}
+
+pub async fn test_mysql_checkpoint_table() {
+    setup_logging();
+    run_test_with_docker(DOCKER_COMPOSE_FILE, || async {
+        assert_sql_checkpoint_round_trip(DATABASE_URL, "mysql").await;
+    })
+    .await;
+}
+
 async fn run_mysql_test<F, Fut>(runner: F)
 where
     F: FnOnce(String) -> Fut,

--- a/tests/integration/mysql.rs
+++ b/tests/integration/mysql.rs
@@ -139,7 +139,9 @@ pub async fn assert_cursor_reads_unmappable_types(database_url: &str, cursor_id:
         url: database_url.to_string(),
         table: "typed_events".to_string(),
         cursor_column: Some("id".to_string()),
-        cursor_id: Some(cursor_id.to_string()),
+        // Unique per run: a persisted cursor from a previous run would resume past all
+        // 3 rows and return an empty batch.
+        cursor_id: Some(format!("{cursor_id}-{}", fast_uuid_v7::gen_id())),
         ..Default::default()
     };
 

--- a/tests/integration/nats.rs
+++ b/tests/integration/nats.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use std::sync::Arc;
 
+use super::assert_permanent_consumer_error;
 use mq_bridge::endpoints::nats::{NatsConsumer, NatsPublisher};
 use mq_bridge::test_utils::{
     add_performance_result, run_chaos_pipeline_test, run_direct_perf_test,
@@ -337,31 +338,4 @@ pub async fn test_nats_subject_stream_mismatch_fails_fast() {
         assert_permanent_consumer_error(route, &route_name, "subject/stream mismatch").await;
     })
     .await;
-}
-
-/// Assert that running `route` once fails with a `ConsumerError::Permanent`.
-///
-/// This targets the classification itself, which is what decides the route's fate:
-/// `route.rs` breaks out of the reconnect loop only for `Permanent`, so anything else spins
-/// on the reconnect interval forever. `run_until_err` is used rather than `run` because a
-/// permanent failure *during startup* reaches the caller of `run` as the same generic
-/// "failed to start" error as a timeout — the very ambiguity that hid these diagnoses.
-async fn assert_permanent_consumer_error(route: mq_bridge::Route, route_name: &str, label: &str) {
-    use mq_bridge::traits::ConsumerError;
-
-    let err = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        route.run_until_err(route_name, None, None),
-    )
-    .await
-    .unwrap_or_else(|_| panic!("'{label}': route neither completed nor failed"))
-    .expect_err("must fail");
-
-    assert!(
-        matches!(
-            err.downcast_ref::<ConsumerError>(),
-            Some(ConsumerError::Permanent(_))
-        ),
-        "'{label}': must be a permanent error so the route stops; got: {err:#}"
-    );
 }

--- a/tests/integration/nats.rs
+++ b/tests/integration/nats.rs
@@ -291,3 +291,77 @@ pub async fn test_nats_drain_exits_on_empty() {
     })
     .await;
 }
+
+/// A route whose `stream`/`subject` pair conflicts with an existing stream can never
+/// succeed: every reconnect rebuilds the identical mismatch. It must terminate the route with
+/// a permanent error instead of looping on the reconnect interval forever.
+///
+/// The reproducible form is a second stream claiming a subject the first already owns
+/// (JetStream error 10065). Note that a consumer whose `filter_subject` merely falls outside
+/// its stream's subjects is *accepted* by the server — it just never delivers — so that
+/// variant is silent starvation rather than an error loop.
+pub async fn test_nats_subject_stream_mismatch_fails_fast() {
+    use mq_bridge::models::{Endpoint, EndpointType, NatsConfig};
+    use mq_bridge::Route;
+
+    setup_logging();
+    run_test_with_docker("tests/integration/docker-compose/nats.yml", || async {
+        let stream = format!("mismatch_stream_{}", fast_uuid_v7::gen_id());
+
+        // Bind the stream to exactly `<stream>.data`. A consumer creates the stream with its
+        // own subject verbatim (the publisher would instead register a `<stream>.>` wildcard,
+        // which covers everything and cannot mismatch).
+        let seed = NatsConsumer::new(&NatsConfig {
+            url: "nats://localhost:4222".to_string(),
+            subject: Some(format!("{stream}.data")),
+            stream: Some(stream.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("create the stream via a matching consumer");
+        drop(seed);
+
+        // Ask for a *different* stream carrying the same subject. NATS refuses to create it
+        // ("subjects overlap with an existing stream"), and no retry can change that.
+        let in_config = NatsConfig {
+            url: "nats://localhost:4222".to_string(),
+            subject: Some(format!("{stream}.data")),
+            stream: Some(format!("{stream}_other")),
+            ..Default::default()
+        };
+        let route_name = format!("nats_mismatch_{}", fast_uuid_v7::gen_id());
+        let input = Endpoint::new(EndpointType::Nats(in_config));
+        let output = Endpoint::new_memory(&route_name, 16);
+        let route = Route::new(input, output);
+
+        assert_permanent_consumer_error(route, &route_name, "subject/stream mismatch").await;
+    })
+    .await;
+}
+
+/// Assert that running `route` once fails with a `ConsumerError::Permanent`.
+///
+/// This targets the classification itself, which is what decides the route's fate:
+/// `route.rs` breaks out of the reconnect loop only for `Permanent`, so anything else spins
+/// on the reconnect interval forever. `run_until_err` is used rather than `run` because a
+/// permanent failure *during startup* reaches the caller of `run` as the same generic
+/// "failed to start" error as a timeout — the very ambiguity that hid these diagnoses.
+async fn assert_permanent_consumer_error(route: mq_bridge::Route, route_name: &str, label: &str) {
+    use mq_bridge::traits::ConsumerError;
+
+    let err = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        route.run_until_err(route_name, None, None),
+    )
+    .await
+    .unwrap_or_else(|_| panic!("'{label}': route neither completed nor failed"))
+    .expect_err("must fail");
+
+    assert!(
+        matches!(
+            err.downcast_ref::<ConsumerError>(),
+            Some(ConsumerError::Permanent(_))
+        ),
+        "'{label}': must be a permanent error so the route stops; got: {err:#}"
+    );
+}

--- a/tests/integration/object_store.rs
+++ b/tests/integration/object_store.rs
@@ -163,3 +163,128 @@ async fn wait_for_batch(consumer: &mut ObjectStoreConsumer) -> mq_bridge::traits
         );
     }
 }
+
+/// An `s3://` `checkpoint_store` must resolve static credentials and a custom endpoint from
+/// the environment. Bare `object_store::parse_url` reads no env at all and falls through to
+/// the EC2 metadata service, which made cloud checkpoints unusable against LocalStack/R2.
+pub async fn test_object_store_checkpoint_round_trip() {
+    setup_logging();
+    run_test_with_docker(
+        "tests/integration/docker-compose/object_store.yml",
+        || async {
+            set_s3_env();
+            ensure_bucket().await;
+
+            let cursor_id = format!("cp-{}", fast_uuid_v7::gen_id());
+            let spec = format!("s3://{BUCKET}/cursors");
+            let backend = mq_bridge::checkpoint::parse_checkpoint_store(&spec)
+                .expect("parse s3 checkpoint_store");
+
+            let store =
+                mq_bridge::checkpoint::build_external_store(backend.clone(), "mysql", &cursor_id)
+                    .await
+                    .expect("build s3 checkpoint store (creds must come from env)");
+            assert_eq!(store.load().await.unwrap(), None, "fresh cursor is empty");
+            store.save("42").await.expect("save cursor");
+            assert_eq!(store.load().await.unwrap(), Some("42".to_string()));
+            store.save("99").await.expect("overwrite cursor");
+
+            // A freshly built store for the same cursor sees the persisted value.
+            let reopened =
+                mq_bridge::checkpoint::build_external_store(backend, "mysql", &cursor_id)
+                    .await
+                    .expect("rebuild s3 checkpoint store");
+            assert_eq!(reopened.load().await.unwrap(), Some("99".to_string()));
+        },
+    )
+    .await;
+}
+
+/// Both permanent object_store misconfigurations must terminate the route as `Failed`
+/// instead of spinning on the reconnect interval forever:
+///
+/// * an object larger than `max_object_bytes` — it will never shrink, so every retry
+///   re-lists it and emits the same warning (this is what made `--drain` hang at zero rows);
+/// * a `checkpoint_store` overlapping the source prefix — a config error, so rebuilding the
+///   consumer reproduces it exactly.
+pub async fn test_object_store_permanent_errors_fail_fast() {
+    use mq_bridge::models::{Endpoint, EndpointType};
+    use mq_bridge::Route;
+
+    setup_logging();
+    run_test_with_docker(
+        "tests/integration/docker-compose/object_store.yml",
+        || async {
+            set_s3_env();
+            ensure_bucket().await;
+
+            // Seed one object that is comfortably over the limit set below.
+            let prefix = format!("permanent/{}", fast_uuid_v7::gen_id_str());
+            let publisher = ObjectStorePublisher::new(&config(&prefix, None))
+                .await
+                .expect("create publisher");
+            publisher
+                .send_batch((1..=20).map(json_msg).collect::<Vec<_>>())
+                .await
+                .expect("seed objects");
+            drop(publisher);
+
+            let cases: Vec<(&str, ObjectStoreConfig)> = vec![
+                (
+                    "max_object_bytes",
+                    ObjectStoreConfig {
+                        max_object_bytes: Some(4),
+                        ..config(
+                            &prefix,
+                            Some("file:///tmp/mqb-permanent-cursor.json".into()),
+                        )
+                    },
+                ),
+                (
+                    "checkpoint overlaps source prefix",
+                    ObjectStoreConfig {
+                        cursor_id: Some("overlap-test".to_string()),
+                        checkpoint_store: Some(format!("s3://{BUCKET}/{prefix}/cursor")),
+                        ..config(&prefix, None)
+                    },
+                ),
+            ];
+
+            for (label, cfg) in cases {
+                let route_name = format!("permanent_{}", fast_uuid_v7::gen_id_str());
+                let input = Endpoint::new(EndpointType::ObjectStore(cfg));
+                let output = Endpoint::new_memory(&route_name, 1024);
+                let route = Route::new(input, output);
+                assert_permanent_consumer_error(route, &route_name, label).await;
+            }
+        },
+    )
+    .await;
+}
+
+/// Assert that running `route` once fails with a `ConsumerError::Permanent`.
+///
+/// This targets the classification itself, which is what decides the route's fate:
+/// `route.rs` breaks out of the reconnect loop only for `Permanent`, so anything else spins
+/// on the reconnect interval forever. `run_until_err` is used rather than `run` because a
+/// permanent failure *during startup* reaches the caller of `run` as the same generic
+/// "failed to start" error as a timeout — the very ambiguity that hid these diagnoses.
+async fn assert_permanent_consumer_error(route: mq_bridge::Route, route_name: &str, label: &str) {
+    use mq_bridge::traits::ConsumerError;
+
+    let err = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        route.run_until_err(route_name, None, None),
+    )
+    .await
+    .unwrap_or_else(|_| panic!("'{label}': route neither completed nor failed"))
+    .expect_err("must fail");
+
+    assert!(
+        matches!(
+            err.downcast_ref::<ConsumerError>(),
+            Some(ConsumerError::Permanent(_))
+        ),
+        "'{label}': must be a permanent error so the route stops; got: {err:#}"
+    );
+}

--- a/tests/integration/object_store.rs
+++ b/tests/integration/object_store.rs
@@ -4,6 +4,7 @@
 //! `object_store` reads its backend config (creds/endpoint/region) from the process
 //! environment, so each test sets the LocalStack S3 vars before building endpoints.
 
+use super::assert_permanent_consumer_error;
 use mq_bridge::endpoints::object_store::{ObjectStoreConsumer, ObjectStorePublisher};
 use mq_bridge::models::{FileFormat, ObjectStoreConfig};
 use mq_bridge::test_utils::{run_pipeline_test, run_test_with_docker, setup_logging};
@@ -180,10 +181,13 @@ pub async fn test_object_store_checkpoint_round_trip() {
             let backend = mq_bridge::checkpoint::parse_checkpoint_store(&spec)
                 .expect("parse s3 checkpoint_store");
 
-            let store =
-                mq_bridge::checkpoint::build_external_store(backend.clone(), "mysql", &cursor_id)
-                    .await
-                    .expect("build s3 checkpoint store (creds must come from env)");
+            let store = mq_bridge::checkpoint::build_external_store(
+                backend.clone(),
+                "object_store",
+                &cursor_id,
+            )
+            .await
+            .expect("build s3 checkpoint store (creds must come from env)");
             assert_eq!(store.load().await.unwrap(), None, "fresh cursor is empty");
             store.save("42").await.expect("save cursor");
             assert_eq!(store.load().await.unwrap(), Some("42".to_string()));
@@ -191,7 +195,7 @@ pub async fn test_object_store_checkpoint_round_trip() {
 
             // A freshly built store for the same cursor sees the persisted value.
             let reopened =
-                mq_bridge::checkpoint::build_external_store(backend, "mysql", &cursor_id)
+                mq_bridge::checkpoint::build_external_store(backend, "object_store", &cursor_id)
                     .await
                     .expect("rebuild s3 checkpoint store");
             assert_eq!(reopened.load().await.unwrap(), Some("99".to_string()));
@@ -260,31 +264,4 @@ pub async fn test_object_store_permanent_errors_fail_fast() {
         },
     )
     .await;
-}
-
-/// Assert that running `route` once fails with a `ConsumerError::Permanent`.
-///
-/// This targets the classification itself, which is what decides the route's fate:
-/// `route.rs` breaks out of the reconnect loop only for `Permanent`, so anything else spins
-/// on the reconnect interval forever. `run_until_err` is used rather than `run` because a
-/// permanent failure *during startup* reaches the caller of `run` as the same generic
-/// "failed to start" error as a timeout — the very ambiguity that hid these diagnoses.
-async fn assert_permanent_consumer_error(route: mq_bridge::Route, route_name: &str, label: &str) {
-    use mq_bridge::traits::ConsumerError;
-
-    let err = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        route.run_until_err(route_name, None, None),
-    )
-    .await
-    .unwrap_or_else(|_| panic!("'{label}': route neither completed nor failed"))
-    .expect_err("must fail");
-
-    assert!(
-        matches!(
-            err.downcast_ref::<ConsumerError>(),
-            Some(ConsumerError::Permanent(_))
-        ),
-        "'{label}': must be a permanent error so the route stops; got: {err:#}"
-    );
 }

--- a/tests/integration/postgres_cdc.rs
+++ b/tests/integration/postgres_cdc.rs
@@ -143,6 +143,119 @@ pub async fn test_postgres_cdc_pipeline() {
     .await;
 }
 
+/// `temporary_slot: true` must actually deliver changes, and must leave no slot
+/// behind once the route stops. A Postgres *temporary* slot dies with the session
+/// that created it, so the option is implemented as drop-on-stop instead.
+pub async fn test_postgres_cdc_temporary_slot() {
+    setup_logging();
+    run_test_with_docker(COMPOSE, || async {
+        let slot = "mqb_cdc_temp_slot";
+        reset_schema(slot).await;
+        let mut config = cfg(slot);
+        config.temporary_slot = true;
+
+        let mut consumer = PostgresCdcConsumer::new(&config)
+            .await
+            .expect("create CDC consumer");
+        insert_rows(1..=10).await;
+        let seen = drain_ids(&mut consumer, 10).await;
+        assert_eq!(seen.len(), 10, "temporary_slot route must deliver rows");
+
+        // Graceful stop runs the teardown that drops the slot; the extra `drop` then hits
+        // the fallback in `Drop`, which must be a no-op because teardown is single-shot.
+        consumer.close().await.expect("clean close");
+        drop(consumer);
+        let mut conn = connect_retry().await;
+        let mut remaining = -1i64;
+        for _ in 0..40 {
+            remaining = sqlx::query_scalar(
+                "SELECT count(*) FROM pg_replication_slots WHERE slot_name = $1",
+            )
+            .bind(slot)
+            .fetch_one(&mut conn)
+            .await
+            .expect("count slots");
+            if remaining == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        assert_eq!(
+            remaining, 0,
+            "temporary slot '{slot}' must be dropped on stop"
+        );
+    })
+    .await;
+}
+
+/// Read the slot's durable `confirmed_flush_lsn` as a `pg_lsn` string.
+async fn confirmed_flush_lsn(slot: &str) -> String {
+    let mut conn = connect_retry().await;
+    sqlx::query_scalar::<_, String>(
+        "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name = $1",
+    )
+    .bind(slot)
+    .fetch_one(&mut conn)
+    .await
+    .expect("read confirmed_flush_lsn")
+}
+
+/// `X/Y` hex LSN -> u64, for comparing positions.
+fn lsn_to_u64(lsn: &str) -> u64 {
+    let (hi, lo) = lsn.split_once('/').expect("pg_lsn has the form X/Y");
+    (u64::from_str_radix(hi, 16).expect("lsn high") << 32)
+        | u64::from_str_radix(lo, 16).expect("lsn low")
+}
+
+/// After a clean stop, the slot's `confirmed_flush_lsn` must cover the last delivered and
+/// acked change. The teardown that flushes it runs in `on_disconnect_hook` (awaited by the
+/// route while the runtime is healthy); doing it from `Drop` instead always failed with
+/// "control-plane connect failed: task was cancelled", so the final flush never landed and
+/// the confirmed position lagged the last transaction.
+pub async fn test_postgres_cdc_confirms_lsn_on_clean_stop() {
+    setup_logging();
+    run_test_with_docker(COMPOSE, || async {
+        let slot = "mqb_cdc_flush_slot";
+        reset_schema(slot).await;
+        let mut consumer = PostgresCdcConsumer::new(&cfg(slot))
+            .await
+            .expect("create CDC consumer");
+
+        insert_rows(1..=20).await;
+        let mut last_lsn = 0u64;
+        let mut seen = 0usize;
+        while seen < 20 {
+            let batch = tokio::time::timeout(Duration::from_secs(20), consumer.receive_batch(1024))
+                .await
+                .expect("timed out waiting for CDC events")
+                .expect("receive_batch failed");
+            let n = batch.messages.len();
+            for msg in &batch.messages {
+                let lsn = msg
+                    .metadata
+                    .get("postgres.lsn")
+                    .expect("each change carries postgres.lsn");
+                last_lsn = last_lsn.max(lsn_to_u64(lsn));
+            }
+            seen += n;
+            (batch.commit)(vec![MessageDisposition::Ack; n])
+                .await
+                .expect("commit (ack) failed");
+        }
+        assert!(last_lsn > 0, "delivered changes must carry an LSN");
+
+        // Graceful stop: `close()` awaits the same disconnect hook the route awaits.
+        consumer.close().await.expect("clean close");
+        let confirmed = confirmed_flush_lsn(slot).await;
+        assert!(
+            lsn_to_u64(&confirmed) >= last_lsn,
+            "confirmed_flush_lsn ({confirmed}) must cover the last acked change ({last_lsn:#x}) \
+             after a clean stop"
+        );
+    })
+    .await;
+}
+
 // --- Isolated CDC read benchmarks ---------------------------------------------------------------
 // Unlike the coupled pipeline test (which times INSERT + WAL + read together and is therefore
 // write-bound), these attach the reader first, seed the table *untimed* — the changes buffer in the

--- a/tests/integration/redis_streams.rs
+++ b/tests/integration/redis_streams.rs
@@ -226,6 +226,115 @@ pub async fn test_redis_drain_exits_on_empty() {
     .await;
 }
 
+/// A replacement consumer must reclaim a backlog left by dead consumers even when the
+/// `>` side of the stream is already fully delivered (`lag: 0`).
+///
+/// Regression for a permanent wedge: the reclaiming reader issued `XAUTOCLAIM` on the same
+/// multiplexed connection it then parked in `XREAD BLOCK`. With nothing new arriving the
+/// read really blocks, so the claim reply could time out client-side *after* the server had
+/// applied it — the entries moved into the new consumer's own PEL and were never delivered,
+/// and every retry re-claimed them and reset their idle time. The route stayed `healthy`.
+///
+/// The shape matters: two dead consumers holding the backlog, a drained `>` side, several
+/// reader connections, `batch_size` larger than the backlog, and `block_ms` equal to
+/// `redelivery_timeout_ms` so the reclaim fires on every blocked read.
+pub async fn test_redis_reclaims_backlog_with_drained_stream() {
+    use mq_bridge::models::{Endpoint, EndpointType, RedisStreamsConfig};
+    use mq_bridge::traits::{MessageConsumer, MessagePublisher};
+    use mq_bridge::{CanonicalMessage, Route};
+
+    setup_logging();
+    run_test_with_docker(COMPOSE, || async {
+        const N: usize = 200;
+        let stream = format!("reclaim_redis_{}", fast_uuid_v7::gen_id());
+        let group = format!("g_reclaim_{}", fast_uuid_v7::gen_id());
+
+        let base = |consumer_name: Option<String>| RedisStreamsConfig {
+            url: URL.to_string(),
+            stream: Some(stream.clone()),
+            group: Some(group.clone()),
+            read_from_start: true,
+            consumer_name,
+            redelivery_timeout_ms: Some(1000),
+            block_ms: Some(1000),
+            ..Default::default()
+        };
+
+        RedisStreamsPublisher::new(&base(None))
+            .await
+            .unwrap()
+            .send_batch(
+                (0..N)
+                    .map(|i| CanonicalMessage::new(format!("msg-{i}").into_bytes(), None))
+                    .collect(),
+            )
+            .await
+            .unwrap();
+
+        // Two consumers read the whole stream and are dropped without acking: the backlog
+        // ends up pending under two now-dead names and `>` has nothing left to deliver.
+        let mut drained = 0usize;
+        for i in 0..2 {
+            let mut dead = RedisStreamsConsumer::new(&base(Some(format!("dead-{i}"))))
+                .await
+                .unwrap();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+            while drained < N * (i + 1) / 2 && std::time::Instant::now() < deadline {
+                let batch =
+                    tokio::time::timeout(std::time::Duration::from_secs(5), dead.receive_batch(16))
+                        .await;
+                match batch {
+                    Ok(Ok(b)) => drained += b.messages.len(),
+                    _ => break,
+                }
+            }
+            drop(dead);
+        }
+        assert!(drained > 0, "seeding left no pending entries");
+
+        // The replacement: batch_size well above the backlog, several reader connections.
+        let out_topic = format!("reclaim_out_{}", fast_uuid_v7::gen_id());
+        let output = Endpoint::new_memory(&out_topic, N + 100);
+        let mut in_config = base(None);
+        in_config.reader_connections = Some(4);
+        let route = Route::new(
+            Endpoint::new(EndpointType::RedisStreams(in_config)),
+            output.clone(),
+        )
+        .with_batch_size(512)
+        .with_concurrency(4);
+
+        let mut sink = output.create_consumer("reclaim_sink").await.unwrap();
+        let handle = route.run("redis_reclaim_test").await.unwrap();
+
+        let mut received = 0usize;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        while received < drained {
+            let batch =
+                tokio::time::timeout(std::time::Duration::from_secs(20), sink.receive_batch(512))
+                    .await
+                    .unwrap_or_else(|_| {
+                        panic!("reclaim wedged: {received}/{drained} entries redelivered")
+                    })
+                    .unwrap();
+            received += batch.messages.len();
+            (batch.commit)(vec![
+                mq_bridge::traits::MessageDisposition::Ack;
+                batch.messages.len()
+            ])
+            .await
+            .unwrap();
+            assert!(
+                std::time::Instant::now() < deadline,
+                "reclaim wedged: {received}/{drained} entries redelivered"
+            );
+        }
+        handle.stop().await;
+        println!("[Redis] Reclaim-with-drained-stream test successful ({received} entries).");
+    })
+    .await;
+}
+
 /// A partial batch must be delivered immediately, not withheld until `batch_size` entries
 /// have accumulated. `receive_batch` blocks for the *first* entry, then drains whatever else
 /// is already pending — so two entries answer a `receive_batch(1024)` at once.

--- a/tests/integration/redis_streams.rs
+++ b/tests/integration/redis_streams.rs
@@ -281,15 +281,27 @@ pub async fn test_redis_reclaims_backlog_with_drained_stream() {
                 .await
                 .unwrap();
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+            let mut received = 0usize;
             while drained_ids.len() < N * (i + 1) / 2 && std::time::Instant::now() < deadline {
                 let batch =
                     tokio::time::timeout(std::time::Duration::from_secs(5), dead.receive_batch(16))
                         .await;
                 match batch {
-                    Ok(Ok(b)) => drained_ids.extend(b.messages.iter().map(|m| m.payload.clone())),
-                    _ => break,
+                    Ok(Ok(b)) => {
+                        received += b.messages.len();
+                        drained_ids.extend(b.messages.iter().map(|m| m.payload.clone()));
+                    }
+                    Ok(Err(e)) => {
+                        eprintln!("dead-{i}: receive_batch failed: {e:?}");
+                        break;
+                    }
+                    Err(e) => {
+                        eprintln!("dead-{i}: receive_batch timed out: {e}");
+                        break;
+                    }
                 }
             }
+            assert!(received > 0, "dead-{i} received no messages");
             drop(dead);
         }
         let drained = drained_ids.len();

--- a/tests/integration/redis_streams.rs
+++ b/tests/integration/redis_streams.rs
@@ -225,3 +225,81 @@ pub async fn test_redis_drain_exits_on_empty() {
     })
     .await;
 }
+
+/// A partial batch must be delivered immediately, not withheld until `batch_size` entries
+/// have accumulated. `receive_batch` blocks for the *first* entry, then drains whatever else
+/// is already pending — so two entries answer a `receive_batch(1024)` at once.
+///
+/// Reported as a bug against v0.3.8 (a route stalling at the app's default batch_size of
+/// 1024); it did not reproduce at either level, so these pin the behaviour instead.
+pub async fn test_redis_partial_batch_is_delivered() {
+    use mq_bridge::models::{Endpoint, EndpointType, RedisStreamsConfig};
+    use mq_bridge::traits::{MessageConsumer, MessagePublisher};
+    use mq_bridge::{CanonicalMessage, Route};
+
+    setup_logging();
+    run_test_with_docker(COMPOSE, || async {
+        let config = |suffix: &str| RedisStreamsConfig {
+            url: URL.to_string(),
+            stream: Some(format!("partial_{suffix}_{}", fast_uuid_v7::gen_id())),
+            group: Some(format!("g_partial_{suffix}")),
+            read_from_start: true,
+            ..Default::default()
+        };
+        let two = || {
+            vec![
+                CanonicalMessage::new(b"v1".to_vec(), None),
+                CanonicalMessage::new(b"v2".to_vec(), None),
+            ]
+        };
+
+        // Consumer level. Entries are published *before* the group exists, matching the report.
+        let cfg = config("consumer");
+        RedisStreamsPublisher::new(&cfg)
+            .await
+            .unwrap()
+            .send_batch(two())
+            .await
+            .unwrap();
+        let mut consumer = RedisStreamsConsumer::new(&cfg).await.unwrap();
+        let batch = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            consumer.receive_batch(1024),
+        )
+        .await
+        .expect("receive_batch never returned: a partial batch was withheld")
+        .unwrap();
+        assert_eq!(
+            batch.messages.len(),
+            2,
+            "both pending entries must arrive in one under-full batch"
+        );
+
+        // Route level, at the app's default batch_size.
+        let cfg = config("route");
+        RedisStreamsPublisher::new(&cfg)
+            .await
+            .unwrap()
+            .send_batch(two())
+            .await
+            .unwrap();
+        let out_topic = format!("partial_out_{}", fast_uuid_v7::gen_id());
+        let output = Endpoint::new_memory(&out_topic, 100);
+        let route = Route::new(
+            Endpoint::new(EndpointType::RedisStreams(cfg)),
+            output.clone(),
+        )
+        .with_batch_size(1024);
+        let handle = route.run("redis_partial_batch").await.unwrap();
+
+        let mut sink = output.create_consumer("partial_sink").await.unwrap();
+        let batch =
+            tokio::time::timeout(std::time::Duration::from_secs(10), sink.receive_batch(1024))
+                .await
+                .expect("nothing reached the sink: the route withheld a partial batch")
+                .unwrap();
+        assert!(!batch.messages.is_empty());
+        handle.stop().await;
+    })
+    .await;
+}

--- a/tests/integration/redis_streams.rs
+++ b/tests/integration/redis_streams.rs
@@ -273,23 +273,26 @@ pub async fn test_redis_reclaims_backlog_with_drained_stream() {
 
         // Two consumers read the whole stream and are dropped without acking: the backlog
         // ends up pending under two now-dead names and `>` has nothing left to deliver.
-        let mut drained = 0usize;
+        // Counted as distinct payloads: the second dead consumer may reclaim entries that
+        // are already pending under `dead-0`, so deliveries overcount the backlog.
+        let mut drained_ids = std::collections::HashSet::new();
         for i in 0..2 {
             let mut dead = RedisStreamsConsumer::new(&base(Some(format!("dead-{i}"))))
                 .await
                 .unwrap();
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
-            while drained < N * (i + 1) / 2 && std::time::Instant::now() < deadline {
+            while drained_ids.len() < N * (i + 1) / 2 && std::time::Instant::now() < deadline {
                 let batch =
                     tokio::time::timeout(std::time::Duration::from_secs(5), dead.receive_batch(16))
                         .await;
                 match batch {
-                    Ok(Ok(b)) => drained += b.messages.len(),
+                    Ok(Ok(b)) => drained_ids.extend(b.messages.iter().map(|m| m.payload.clone())),
                     _ => break,
                 }
             }
             drop(dead);
         }
+        let drained = drained_ids.len();
         assert!(drained > 0, "seeding left no pending entries");
 
         // The replacement: batch_size well above the backlog, several reader connections.
@@ -307,9 +310,10 @@ pub async fn test_redis_reclaims_backlog_with_drained_stream() {
         let mut sink = output.create_consumer("reclaim_sink").await.unwrap();
         let handle = route.run("redis_reclaim_test").await.unwrap();
 
-        let mut received = 0usize;
+        let mut received_ids = std::collections::HashSet::new();
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
-        while received < drained {
+        while received_ids.len() < drained {
+            let received = received_ids.len();
             let batch =
                 tokio::time::timeout(std::time::Duration::from_secs(20), sink.receive_batch(512))
                     .await
@@ -317,7 +321,7 @@ pub async fn test_redis_reclaims_backlog_with_drained_stream() {
                         panic!("reclaim wedged: {received}/{drained} entries redelivered")
                     })
                     .unwrap();
-            received += batch.messages.len();
+            received_ids.extend(batch.messages.iter().map(|m| m.payload.clone()));
             (batch.commit)(vec![
                 mq_bridge::traits::MessageDisposition::Ack;
                 batch.messages.len()
@@ -326,11 +330,15 @@ pub async fn test_redis_reclaims_backlog_with_drained_stream() {
             .unwrap();
             assert!(
                 std::time::Instant::now() < deadline,
-                "reclaim wedged: {received}/{drained} entries redelivered"
+                "reclaim wedged: {}/{drained} entries redelivered",
+                received_ids.len()
             );
         }
         handle.stop().await;
-        println!("[Redis] Reclaim-with-drained-stream test successful ({received} entries).");
+        println!(
+            "[Redis] Reclaim-with-drained-stream test successful ({} entries).",
+            received_ids.len()
+        );
     })
     .await;
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -400,6 +400,16 @@ async fn test_mongodb_cdc_latency() {
     }
 }
 
+/// Regression: an idle change stream must survive the idle resume-token refresh (no abort).
+#[cfg(feature = "mongodb")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (mongodb replica set)"]
+async fn test_mongodb_cdc_survives_idle_resume_refresh() {
+    if should_run("mongodb_cdc") || should_run("mongodb") {
+        integration::mongodb::test_mongodb_cdc_survives_idle_resume_refresh().await;
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "requires docker compose, takes long time to run"]
 async fn test_all_performance_pipeline() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -118,6 +118,8 @@ async fn test_all_subscriber_logic() {
             integration::redis_streams::test_redis_drain_exits_on_empty().await;
             println!("\n\n>>> Starting Redis Streams Partial Batch Test...");
             integration::redis_streams::test_redis_partial_batch_is_delivered().await;
+            println!("\n\n>>> Starting Redis Streams Reclaim (drained stream) Test...");
+            integration::redis_streams::test_redis_reclaims_backlog_with_drained_stream().await;
         }
     }
     #[cfg(feature = "amqp")]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -116,6 +116,8 @@ async fn test_all_subscriber_logic() {
             integration::redis_streams::test_redis_subscriber_logic().await;
             println!("\n\n>>> Starting Redis Streams Drain (exit_on_empty) Test...");
             integration::redis_streams::test_redis_drain_exits_on_empty().await;
+            println!("\n\n>>> Starting Redis Streams Partial Batch Test...");
+            integration::redis_streams::test_redis_partial_batch_is_delivered().await;
         }
     }
     #[cfg(feature = "amqp")]
@@ -333,12 +335,93 @@ async fn test_postgres_cdc() {
     }
 }
 
+#[cfg(all(feature = "postgres-cdc", feature = "test-utils"))]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (postgres with wal_level=logical)"]
+async fn test_postgres_cdc_temporary_slot() {
+    if should_run("postgres_cdc") || should_run("postgres") {
+        integration::postgres_cdc::test_postgres_cdc_temporary_slot().await;
+    }
+}
+
+#[cfg(feature = "sqlx")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (mysql)"]
+async fn test_mysql_cursor_unmappable_types() {
+    if should_run("sqlx") || should_run("mysql") {
+        integration::mysql::test_mysql_cursor_unmappable_types().await;
+    }
+}
+
+#[cfg(feature = "sqlx")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (mariadb)"]
+async fn test_mariadb_cursor_unmappable_types() {
+    if should_run("sqlx") || should_run("mariadb") {
+        integration::mariadb::test_mariadb_cursor_unmappable_types().await;
+    }
+}
+
+#[cfg(feature = "sqlx")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (mysql)"]
+async fn test_mysql_checkpoint_table() {
+    if should_run("sqlx") || should_run("mysql") {
+        integration::mysql::test_mysql_checkpoint_table().await;
+    }
+}
+
+#[cfg(feature = "sqlx")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (mariadb)"]
+async fn test_mariadb_checkpoint_table() {
+    if should_run("sqlx") || should_run("mariadb") {
+        integration::mariadb::test_mariadb_checkpoint_table().await;
+    }
+}
+
+#[cfg(feature = "nats")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (nats)"]
+async fn test_nats_subject_stream_mismatch_fails_fast() {
+    if should_run("nats") {
+        integration::nats::test_nats_subject_stream_mismatch_fails_fast().await;
+    }
+}
+
+#[cfg(all(feature = "postgres-cdc", feature = "test-utils"))]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (postgres with wal_level=logical)"]
+async fn test_postgres_cdc_confirms_lsn_on_clean_stop() {
+    if should_run("postgres_cdc") || should_run("postgres") {
+        integration::postgres_cdc::test_postgres_cdc_confirms_lsn_on_clean_stop().await;
+    }
+}
+
 #[cfg(feature = "object-store")]
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "requires docker compose (localstack s3)"]
 async fn test_object_store_pipeline() {
     if should_run("object_store") {
         integration::object_store::test_object_store_pipeline().await;
+    }
+}
+
+#[cfg(feature = "object-store")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (localstack s3)"]
+async fn test_object_store_checkpoint_round_trip() {
+    if should_run("object_store") {
+        integration::object_store::test_object_store_checkpoint_round_trip().await;
+    }
+}
+
+#[cfg(feature = "object-store")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires docker compose (localstack s3)"]
+async fn test_object_store_permanent_errors_fail_fast() {
+    if should_run("object_store") {
+        integration::object_store::test_object_store_permanent_errors_fail_fast().await;
     }
 }
 

--- a/tests/reference_docs_test.rs
+++ b/tests/reference_docs_test.rs
@@ -1,10 +1,61 @@
 //! Parses every config shape documented in REFERENCE.md.
 //!
 //! The reference file is the place people (and LLMs) look up what exists and how to spell
-//! it, so a snippet that does not deserialize is a real bug. Add a case here whenever a
-//! middleware or structural endpoint is added or its config changes.
+//! it, so a snippet that does not deserialize is a real bug.
+//!
+//! The snippets are read out of REFERENCE.md itself rather than copied here, so a doc edit
+//! is tested as written and cannot drift from a stale duplicate. A fenced block opts in by
+//! tagging its info string — ```yaml middleware, ```yaml endpoint or ```yaml route; a plain
+//! ```yaml block is prose and is skipped. Only cases a fence cannot express (the `null`
+//! spelling, behavioural rules) stay hand-written below.
 
 use mq_bridge::models::{Endpoint, Middleware};
+use std::collections::HashMap;
+
+const REFERENCE: &str = include_str!("../REFERENCE.md");
+
+/// A fenced code block lifted out of REFERENCE.md.
+struct Fence {
+    /// 1-based line of the opening fence, for failure messages.
+    line: usize,
+    info: String,
+    body: String,
+}
+
+/// Splits REFERENCE.md into its fenced code blocks.
+fn fenced_blocks() -> Vec<Fence> {
+    let mut blocks = Vec::new();
+    let mut open: Option<(usize, String, Vec<&str>)> = None;
+
+    for (index, line) in REFERENCE.lines().enumerate() {
+        match (line.strip_prefix("```"), open.as_mut()) {
+            (Some(_), Some(_)) => {
+                let (line_no, info, body) = open.take().expect("checked open above");
+                blocks.push(Fence {
+                    line: line_no,
+                    info,
+                    body: body.join("\n"),
+                });
+            }
+            (Some(info), None) => open = Some((index + 1, info.trim().to_string(), Vec::new())),
+            (None, Some((_, _, body))) => body.push(line),
+            (None, None) => {}
+        }
+    }
+
+    if let Some((line_no, info, _)) = open {
+        panic!("REFERENCE.md has an unterminated ```{info} fence opened at line {line_no}");
+    }
+    blocks
+}
+
+/// The blocks tagged with `tag`.
+fn tagged(tag: &str) -> Vec<Fence> {
+    fenced_blocks()
+        .into_iter()
+        .filter(|fence| fence.info == tag)
+        .collect()
+}
 
 /// Indents every non-empty line, so a doc snippet can be embedded under a YAML key.
 fn indent(yaml: &str, spaces: usize) -> String {
@@ -22,20 +73,17 @@ fn indent(yaml: &str, spaces: usize) -> String {
         .join("\n")
 }
 
-/// Parses a `middlewares:` list entry exactly as it appears in the reference — middleware
-/// is only ever deserialized as part of an endpoint, never standalone.
-fn middleware(entry_yaml: &str) -> Middleware {
+/// Parses a `middlewares:` list exactly as it appears in the reference — middleware is only
+/// ever deserialized as part of an endpoint, never standalone.
+fn middlewares(entries_yaml: &str, line: usize) -> Vec<Middleware> {
     let doc = format!(
         "middlewares:\n{}\nmemory: {{ topic: \"reference_probe\" }}\n",
-        indent(entry_yaml, 2)
+        indent(entries_yaml, 2)
     );
-    let endpoint: Endpoint = serde_yaml_ng::from_str(&doc)
-        .unwrap_or_else(|e| panic!("REFERENCE.md middleware snippet does not parse: {e}\n{doc}"));
-    endpoint
-        .middlewares
-        .into_iter()
-        .next()
-        .expect("snippet should yield one middleware")
+    let endpoint: Endpoint = serde_yaml_ng::from_str(&doc).unwrap_or_else(|e| {
+        panic!("REFERENCE.md middleware block at line {line} does not parse: {e}\n{doc}")
+    });
+    endpoint.middlewares
 }
 
 fn endpoint(yaml: &str) -> Endpoint {
@@ -43,147 +91,91 @@ fn endpoint(yaml: &str) -> Endpoint {
         .unwrap_or_else(|e| panic!("REFERENCE.md endpoint snippet does not parse: {e}\n{yaml}"))
 }
 
+/// Endpoint blocks in the reference are shown in place, under the `input:` / `output:` key
+/// they would occupy in a route. A block may hold several such fragments, separated by a
+/// blank line (e.g. the publisher and consumer sides of `stream_buffer`).
+fn endpoints(body: &str, line: usize) -> Vec<Endpoint> {
+    let mut found = Vec::new();
+    for chunk in body.split("\n\n") {
+        if chunk.trim().is_empty() {
+            continue;
+        }
+        let fragment: HashMap<String, Endpoint> =
+            serde_yaml_ng::from_str(chunk).unwrap_or_else(|e| {
+                panic!("REFERENCE.md endpoint block at line {line} does not parse: {e}\n{chunk}")
+            });
+        for (key, value) in fragment {
+            assert!(
+                key == "input" || key == "output",
+                "REFERENCE.md endpoint block at line {line} uses key '{key}'; \
+                 expected the fragment to sit under 'input' or 'output'"
+            );
+            found.push(value);
+        }
+    }
+    assert!(
+        !found.is_empty(),
+        "REFERENCE.md endpoint block at line {line} yielded no endpoints"
+    );
+    found
+}
+
+/// Every middleware documented in the reference, parsed from the doc itself.
 #[test]
 fn documented_middleware_snippets_parse() {
-    let snippets = [
-        r#"- retry: { max_attempts: 5, initial_interval_ms: 200, max_interval_ms: 10000, multiplier: 2.0 }"#,
-        r#"- dlq: { endpoint: { file: { path: "dead-letters.jsonl" } } }"#,
-        r#"
-- transform:
-    mapping:
-      firstName: "$.first_name"
-      id: "$.user_id"
-      "address.city": { path: "$.city", default: "unknown" }
-    schema_file: "schemas/user.json"
-"#,
-        r#"
-- transform:
-    schema:
-      type: object
-      properties:
-        payload:
-          type: string
-          contentMediaType: application/json
-          contentSchema:
-            type: object
-            properties:
-              qty: { type: integer }
-"#,
-        r#"- deduplication: { sled_path: "/var/lib/mq-bridge/dedup", ttl_seconds: 3600 }"#,
-        r#"- deduplication: { store: "sled:///var/lib/mq-bridge/dedup", ttl_seconds: 3600 }"#,
-        r#"- deduplication: { store: "mongodb://localhost:27017/etl", ttl_seconds: 3600 }"#,
-        r#"- deduplication: { store: "postgres://user:pass@localhost/etl", ttl_seconds: 3600 }"#,
-        r#"- weak_join: { group_by: "correlation_id", expected_count: 3, timeout_ms: 5000 }"#,
-        r#"
-- weak_join:
-    group_by: "correlation_id"
-    expected_count: 2
-    timeout_ms: 5000
-    branch_by: "source"
-    required: ["inventory", "pricing"]
-    on_timeout: discard
-"#,
-        r#"- buffer: { max_messages: 500, max_delay_ms: 20 }"#,
-        r#"- limiter: { messages_per_second: 250 }"#,
-        r#"- delay: { delay_ms: 100 }"#,
-        r#"
-- cookie_jar:
-    shared_scope: "login-session"
-    capture_metadata_keys: ["x-csrf-token"]
-    export_metadata_prefix: "session."
-"#,
-        r#"- encryption: { key: "${env:MQB_ENC_KEY}" }"#,
-        r#"
-- encryption:
-    cipher: aes256gcm
-    key_id: "k2"
-    key: "${env:MQB_ENC_KEY}"
-    decrypt_keys: { k1: "${env:MQB_OLD_ENC_KEY}" }
-"#,
-        r#"- compression: { algorithm: zstd }"#,
-        r#"- compression: { algorithm: gzip, max_decompressed_bytes: 1048576 }"#,
-        r#"- metrics: {}"#,
-        r#"- random_panic: { mode: disconnect, trigger_on_message: 500 }"#,
-        r#"
-- custom:
-    name: "my_enricher"
-    config: { lookup_url: "http://enrich.internal" }
-"#,
-    ];
-
-    for snippet in snippets {
-        middleware(snippet);
+    let blocks = tagged("yaml middleware");
+    assert!(
+        blocks.len() >= 15,
+        "expected the reference to tag a `yaml middleware` block per middleware section, found {}",
+        blocks.len()
+    );
+    for fence in blocks {
+        let parsed = middlewares(&fence.body, fence.line);
+        assert!(
+            !parsed.is_empty(),
+            "REFERENCE.md middleware block at line {} yielded no middleware",
+            fence.line
+        );
     }
 }
 
+/// Every structural endpoint documented in the reference, parsed from the doc itself.
 #[test]
 fn documented_structural_endpoint_snippets_parse() {
-    let snippets = [
-        r#"ref: "common_queue""#,
-        r#"
-fanout:
-  - kafka: { topic: "audit", url: "localhost:9092" }
-  - file: { path: "audit.jsonl" }
-  - nats: { subject: "audit", url: "nats://localhost:4222" }
-"#,
-        r#"
-switch:
-  metadata_key: "http_status_code"
-  cases:
-    "200": { nats: { subject: "ok", url: "nats://localhost:4222" } }
-    "404": { file: { path: "not-found.jsonl" } }
-  default: { file: { path: "other.jsonl" } }
-"#,
-        r#"
-request:
-  to: { http: { url: "https://api.internal/score" } }
-  forward_to: { ibmmq: { queue: "RESULTS", url: "mq(1414)", queue_manager: "QM1", channel: "APP.SVRCONN" } }
-"#,
-        r#"response: {}"#,
-        r#"
-reader:
-  kafka: { topic: "queue", url: "localhost:9092" }
-"#,
-        r#"static: "OK""#,
-        r#"
-static:
-  body: '{"status":"ok"}'
-  raw: true
-  metadata: { content-type: "application/json" }
-"#,
-        r#"
-static:
-  body: '{"error":"not found","id":"${message:id}","at":"${gen:now}"}'
-  raw: true
-  metadata: { content-type: "application/json" }
-"#,
-        r#"stream_buffer: { topic: "responses" }"#,
-        r#"stream_buffer: { topic: "responses", correlation_id: "req-123" }"#,
-        r#"
-custom:
-  name: "my_sink"
-  config: { target: "internal://thing" }
-"#,
-    ];
-
-    for snippet in snippets {
-        endpoint(snippet);
+    let blocks = tagged("yaml endpoint");
+    assert!(
+        blocks.len() >= 6,
+        "expected the reference to tag a `yaml endpoint` block per structural endpoint section, found {}",
+        blocks.len()
+    );
+    for fence in blocks {
+        endpoints(&fence.body, fence.line);
     }
 }
 
-/// The at-rest compress-then-encrypt example from the `encryption` section.
+/// The complete named-route examples, parsed from the doc itself.
 #[test]
-fn documented_at_rest_encryption_snippet_parses() {
-    let ep = endpoint(
-        r#"
-file:
-  path: "data.enc"
-  format: raw
-  compression: lz4
-  encryption: { key: "${env:MQB_ENC_KEY}" }
-"#,
+fn documented_route_snippets_parse() {
+    let blocks = tagged("yaml route");
+    assert!(
+        blocks.len() >= 5,
+        "expected the reference to tag its complete route examples, found {}",
+        blocks.len()
     );
-    assert_eq!(ep.endpoint_type.name(), "file");
+    for fence in blocks {
+        let routes: HashMap<String, mq_bridge::models::Route> =
+            serde_yaml_ng::from_str(&fence.body).unwrap_or_else(|e| {
+                panic!(
+                    "REFERENCE.md route block at line {} does not parse: {e}\n{}",
+                    fence.line, fence.body
+                )
+            });
+        assert!(
+            !routes.is_empty(),
+            "REFERENCE.md route block at line {} yielded no routes",
+            fence.line
+        );
+    }
 }
 
 /// `null` is the one endpoint whose YAML spelling is a trap. A bare YAML null is the form
@@ -211,41 +203,6 @@ input:
     )
     .unwrap();
     assert_eq!(route.output.endpoint_type.name(), "null");
-}
-
-/// Full route shapes used as examples in the reference.
-#[test]
-fn documented_route_snippets_parse() {
-    let routes = [
-        r#"
-input:
-  middlewares:
-    - deduplication: { sled_path: "/var/lib/mqb/dedup", ttl_seconds: 3600 }
-  kafka: { topic: "orders", url: "localhost:9092" }
-output:
-  middlewares:
-    - retry: { max_attempts: 5 }
-    - dlq: { endpoint: { file: { path: "failed.jsonl" } } }
-  nats: { subject: "orders.processed", url: "nats://localhost:4222" }
-"#,
-        r#"
-input: { http: { url: "0.0.0.0:8080" } }
-output: { response: {} }
-"#,
-        r#"
-input: { ref: "common_queue" }
-output: { nats: { subject: "enriched", url: "nats://localhost:4222" } }
-"#,
-        r#"
-input: { kafka: { topic: "noisy", url: "localhost:9092" } }
-output: null
-"#,
-    ];
-
-    for yaml in routes {
-        let _: mq_bridge::models::Route = serde_yaml_ng::from_str(yaml)
-            .unwrap_or_else(|e| panic!("REFERENCE.md route snippet does not parse: {e}\n{yaml}"));
-    }
 }
 
 /// The reference distinguishes "wrong side, warns and is skipped" from "wrong side, hard


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

<!-- Describe the tests you ran and how to verify your changes -->

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if needed)
- [ ] No new warnings generated
- [ ] Tests added/updated for new functionality
- [ ] All tests pass locally

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Related to #

## Additional Notes

<!-- Any additional information that reviewers should know -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable deduplication keys, retry-attempt metadata, and dead-letter queue metadata.
  * Added route status and outcome reporting, expanded endpoint typing, and environment-aware object-store checkpoints.
  * Improved Redis Streams recovery, binary payload preservation, and database cursor support.

* **Bug Fixes**
  * Improved PostgreSQL CDC cleanup, checkpoint durability, and permanent-error handling.
  * Prevented indefinite waits in streaming, publishing, and endpoint hooks.
  * Improved file validation, MongoDB claiming, encryption handling, and ZeroMQ recovery.

* **Documentation**
  * Clarified checkpoint, compression, encryption, deduplication, and fault-injection behavior.

* **Chores**
  * Incremented the release version to 0.3.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->