### PR TITLE
Fix file record order and resuming SQLite cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "mq-bridge"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "mq-bridge-bindings-common"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "fast-uuid-v7",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "mq-bridge-node"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "mq-bridge-py"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,6 +150,19 @@ Batch processing is a core concept in mq-bridge and is required for all endpoint
 - Each route can be configured with a `concurrency` parameter, which determines how many worker tasks will process batches in parallel.
 - Batch size is also configurable per route.
 
+#### Ordering
+Two independent guarantees, each decided once per route by the endpoint itself:
+
+- **Commits** follow `MessageConsumer::commit_requires_order()` (default `true`). Cumulative-ack sources such as Kafka funnel their commits through one sequencer; individually-acking sources commit concurrently, bounded by `commit_concurrency_limit`.
+- **Publishing** follows `MessagePublisher::requires_ordered_publish()` (default `false`). Above `concurrency: 1` workers call `send_batch` in parallel, so whole batches can reach the sink out of source order — rows keep their order *within* a batch. The `file` sink declares `true` and the route sequences the `send_batch` calls; batch prep and commits stay parallel, so the ordered path measures within noise of an unordered one.
+
+Only `file` declares it, for two reasons that any other candidate has to clear:
+
+- **The cost must be low.** The file sink already holds a write lock across the whole batch, so sequencing changes who writes, not how many write at once. Sequencing a sink that ends in a network round trip instead costs the whole concurrency factor — one batch in flight instead of N.
+- **The guarantee must be reachable.** `object_store` does *not* declare it: read order there is object-key order, and the uuidv7 key randomises everything below the millisecond, so ordering the writes would buy nothing. Ordered cloud export needs a source-sequenced key first.
+
+Broker sinks keep it off. NATS (both Core and JetStream) publishes a batch through `send_batch_helper`, which keeps up to `SEND_BATCH_CONCURRENCY` publishes in flight, so wire order inside one batch is already unordered — only the results are re-sorted. Kafka and AMQP preserve order within a batch (they submit the whole batch, then await confirms), but for them the order-critical part is the cheap submit loop, not the round trip, so a useful fix would have to release the sequence after submit rather than after `send_batch`. For per-key Kafka ordering today, use `concurrency: 1`.
+
 ### Helper Utilities
 mq-bridge provides several helper functions to make implementing batching easier, especially if your endpoint only supports single-message operations:
 

--- a/mq-bridge.schema.json
+++ b/mq-bridge.schema.json
@@ -2972,7 +2972,7 @@
           "minimum": 1
         },
         "concurrency": {
-          "description": "(Optional) Number of concurrent processing tasks for this route. While it improves throughput for high-latency\nhandlers, it adds synchronization overhead for ordered commits and may lead to out-of-order processing\nin the handler. Defaults to 1.",
+          "description": "(Optional) Number of concurrent processing tasks for this route. While it improves throughput for high-latency\nhandlers, it adds synchronization overhead for ordered commits and may lead to out-of-order processing\nin the handler. Above 1, whole batches may also reach the sink out of source order (rows keep their order\nwithin a batch) unless the sink declares itself order-sensitive, as `file` does.\nDefaults to 1.",
           "type": "integer",
           "format": "uint",
           "default": 1,

--- a/src/command_handler.rs
+++ b/src/command_handler.rs
@@ -165,6 +165,10 @@ impl MessagePublisher for CommandPublisher {
         self.inner.status().await
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -1017,6 +1017,12 @@ impl MessagePublisher for FilePublisher {
         Ok(())
     }
 
+    /// A file is an ordered log by construction: appending batches in the order they
+    /// were read is the whole point of exporting to JSONL/CSV.
+    fn requires_ordered_publish(&self) -> bool {
+        true
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/endpoints/file/tests.rs
+++ b/src/endpoints/file/tests.rs
@@ -912,6 +912,100 @@ async fn test_file_consumer_subscribe_explicit_no_delete() {
 
 use crate::models::{Endpoint, EndpointType, Route};
 
+// Regression (issue #71): the reporter's repro — 20 numbered rows, file -> file,
+// batch_size 5, concurrency 4 — used to emit whole batches out of source order
+// (e.g. 15..19 first). A file is an ordered log, so `FilePublisher` declares
+// `requires_ordered_publish()` and the route sequences the sends.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_route_file_to_file_preserves_order_at_concurrency() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("rows.jsonl");
+    let dst = dir.path().join("out.jsonl");
+    let rows: String = (0..20).map(|i| format!("{i}\n")).collect();
+    tokio::fs::write(&src, rows.as_bytes()).await.unwrap();
+
+    let input = Endpoint::new(EndpointType::File(FileConfig {
+        path: src.to_str().unwrap().to_string(),
+        mode: Some(FileConsumerMode::Consume { delete: false }),
+        format: FileFormat::Raw,
+        ..Default::default()
+    }));
+    let output = Endpoint::new(EndpointType::File(FileConfig {
+        path: dst.to_str().unwrap().to_string(),
+        format: FileFormat::Raw,
+        ..Default::default()
+    }));
+    let route = Route::new(input, output)
+        .with_concurrency(4)
+        .with_batch_size(5)
+        .with_exit_on_empty(true);
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        route.run_until_err("file_order_regression", None, None),
+    )
+    .await
+    .expect("Route should drain and exit")
+    .expect("Route should complete without errors");
+
+    let content = tokio::fs::read_to_string(&dst).await.unwrap();
+    let written: Vec<&str> = content.lines().collect();
+    let expected: Vec<String> = (0..20).map(|i| i.to_string()).collect();
+    assert_eq!(written, expected, "File sink must preserve source order");
+}
+
+// A buffering publisher only returns from `send_batch` once its buffer flushed, so
+// sequencing sends must not let it wait for a batch that is itself waiting to be sent.
+// `max_delay_ms` guarantees the flush, but the interaction is worth pinning: this hangs
+// if the ordered path ever gates on something the sink needs first.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_route_ordered_file_sink_with_buffer_does_not_stall() {
+    use crate::models::{BufferMiddleware, Middleware};
+
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("buf_rows.jsonl");
+    let dst = dir.path().join("buf_out.jsonl");
+    let rows: String = (0..20).map(|i| format!("{i}\n")).collect();
+    tokio::fs::write(&src, rows.as_bytes()).await.unwrap();
+
+    let input = Endpoint::new(EndpointType::File(FileConfig {
+        path: src.to_str().unwrap().to_string(),
+        mode: Some(FileConsumerMode::Consume { delete: false }),
+        format: FileFormat::Raw,
+        ..Default::default()
+    }));
+    let mut output = Endpoint::new(EndpointType::File(FileConfig {
+        path: dst.to_str().unwrap().to_string(),
+        format: FileFormat::Raw,
+        ..Default::default()
+    }));
+    // Buffer larger than one batch, so every flush is timer-driven.
+    output
+        .middlewares
+        .push(Middleware::Buffer(BufferMiddleware {
+            max_messages: 50,
+            max_delay_ms: 20,
+        }));
+
+    let route = Route::new(input, output)
+        .with_concurrency(4)
+        .with_batch_size(5)
+        .with_exit_on_empty(true);
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        route.run_until_err("file_order_buffer", None, None),
+    )
+    .await
+    .expect("Ordered sends through a buffer must not stall")
+    .expect("Route should complete without errors");
+
+    let content = tokio::fs::read_to_string(&dst).await.unwrap();
+    let written: Vec<&str> = content.lines().collect();
+    let expected: Vec<String> = (0..20).map(|i| i.to_string()).collect();
+    assert_eq!(written, expected);
+}
+
 #[tokio::test]
 async fn test_route_file_consume_explicit_delete() {
     let dir = tempdir().unwrap();

--- a/src/endpoints/object_store.rs
+++ b/src/endpoints/object_store.rs
@@ -9,8 +9,9 @@
 //! - **Sink** ([`ObjectStorePublisher`]): each flushed batch is encoded (reusing the
 //!   file endpoint's [`FileFormat`] codecs) and written as one immutable object at
 //!   `<prefix>/[YYYY/MM/DD/]<uuidv7>.<ext>`. Objects are write-once; nothing is appended
-//!   or mutated. The uuidv7 name sorts by write time; the date prefix is a readability /
-//!   lifecycle-rule convenience only.
+//!   or mutated. The uuidv7 name sorts by write time to *millisecond* granularity only —
+//!   `rand_a`/`rand_b` are random, so objects written within the same millisecond sort in
+//!   arbitrary order. The date prefix is a readability / lifecycle-rule convenience only.
 //! - **Source** ([`ObjectStoreConsumer`]): objects under `prefix` are listed in key order,
 //!   fetched whole, split by `delimiter`, and emitted. Progress is a durable cursor holding
 //!   the last fully-acked object key (via the external checkpoint store), so a restart
@@ -417,6 +418,11 @@ impl MessagePublisher for ObjectStorePublisher {
     async fn flush(&self) -> anyhow::Result<()> {
         Ok(())
     }
+
+    // Deliberately *not* declaring `requires_ordered_publish()`. Unlike the file sink, read
+    // order here is key order, and `next_key` randomises everything below the millisecond, so
+    // sequencing the writes would cost a latency-bound sink its concurrency without buying an
+    // ordering guarantee. Ordered cloud export needs a source-sequenced key first.
 
     fn as_any(&self) -> &dyn Any {
         self

--- a/src/endpoints/sqlx/mod.rs
+++ b/src/endpoints/sqlx/mod.rs
@@ -1723,6 +1723,22 @@ fn mysql_data_type_is_any_safe(data_type: &str) -> bool {
     )
 }
 
+/// SQLite declared column types that sqlx maps to a `DataType` the `Any` driver rejects.
+/// sqlx-sqlite parses `sqlite3_column_decltype` with `DataType::from_str`, and only these exact
+/// spellings yield `Bool`/`Date`/`Time`/`Datetime` — everything else either maps to a supported
+/// type or fails to parse and falls back to the runtime value type, which is always safe.
+/// Notably this covers the `DATETIME` columns our own `auto_create_table` DDL emits.
+fn sqlite_decltype_is_any_safe(decl_type: &str) -> bool {
+    !matches!(
+        decl_type,
+        "boolean" | "bool" | "date" | "time" | "datetime" | "timestamp"
+    )
+}
+
+/// Binds are the table name and its schema (`main` unless the name was `schema.table`).
+const SQLITE_COLUMN_TYPES_SQL: &str =
+    "SELECT name AS name, LOWER(type) AS typname FROM pragma_table_info(?, ?) ORDER BY cid";
+
 /// `$1::regclass` resolves the (optionally schema-qualified) table name against the current
 /// search_path. `pg_attribute.attname`/`pg_type.typname` are Postgres `name`-typed columns,
 /// which `Any` cannot decode directly (distinct from `text`), so cast them explicitly.
@@ -1744,8 +1760,10 @@ const MYSQL_COLUMN_TYPES_SQL: &str = "SELECT COLUMN_NAME AS name, LOWER(DATA_TYP
 /// query on the first type it cannot map (`TIMESTAMPTZ` on Postgres, `DECIMAL`/`TIMESTAMP` on
 /// MySQL). We introspect the table's columns and cast every `Any`-incompatible column to a
 /// string type, so the copy succeeds (unmappable values arrive as strings) instead of failing
-/// every read forever. Any introspection failure (or an unsupported driver, e.g. SQLite, whose
-/// dynamic typing needs no cast) falls back to `*`, preserving the previous behaviour.
+/// every read forever. SQLite is affected too: its type info comes from the *declared* type, so
+/// a `DATETIME` column — including the ones `auto_create_table` writes — breaks the read.
+/// Any introspection failure (or an unsupported driver) falls back to `*`, preserving the
+/// previous behaviour.
 async fn build_cursor_projection(pool: &AnyPool, driver_name: &str, table: &str) -> String {
     type SafeFn = fn(&str) -> bool;
     type CastFn = fn(&str) -> String;
@@ -1770,6 +1788,21 @@ async fn build_cursor_projection(pool: &AnyPool, driver_name: &str, table: &str)
                 vec![schema, name],
                 mysql_data_type_is_any_safe,
                 |ident| format!("CAST({ident} AS CHAR) AS {ident}"),
+            )
+        }
+        "SQLite" => {
+            let (schema, name) = match table.split_once('.') {
+                Some((s, t)) => (
+                    s.trim_matches('"').to_string(),
+                    t.trim_matches('"').to_string(),
+                ),
+                None => ("main".to_string(), table.trim_matches('"').to_string()),
+            };
+            (
+                SQLITE_COLUMN_TYPES_SQL,
+                vec![name, schema],
+                sqlite_decltype_is_any_safe,
+                |ident| format!("CAST({ident} AS TEXT) AS {ident}"),
             )
         }
         _ => return "*".to_string(),

--- a/src/endpoints/sqlx/tests.rs
+++ b/src/endpoints/sqlx/tests.rs
@@ -1048,8 +1048,13 @@ async fn test_sqlx_auto_created_table_is_cursor_readable() {
     assert_eq!(batch.messages.len(), 3);
     let v: serde_json::Value = serde_json::from_slice(&batch.messages[0].payload).unwrap();
     assert_eq!(v["id"], 1);
-    // The DATETIME columns survive as strings rather than aborting the read.
-    assert!(v.get("created_at").is_some());
+    // The DATETIME columns survive as strings rather than aborting the read. `is_some()`
+    // alone would also pass on a JSON null, which is what a failed cast looks like.
+    assert!(
+        v["created_at"].as_str().is_some(),
+        "got {}",
+        v["created_at"]
+    );
     assert!(v["locked_until"].is_null());
 }
 
@@ -1098,6 +1103,10 @@ async fn test_sqlx_cursor_reader_datetime_cursor_column_resumes() {
     assert_eq!(b1.messages.len(), 2);
     (b1.commit)(vec![MessageDisposition::Ack; 2]).await.unwrap();
 
+    // Resume from the *checkpoint*, not the in-memory cursor: a text-encoded timestamp has
+    // to survive save/load/decode, which reading on through the same reader never exercises.
+    drop(reader);
+    let mut reader = SqlxCursorReader::new(&config).await.unwrap();
     let b2 = reader.receive_batch(2).await.unwrap();
     let notes: Vec<String> = b2
         .messages

--- a/src/endpoints/sqlx/tests.rs
+++ b/src/endpoints/sqlx/tests.rs
@@ -1053,6 +1053,64 @@ async fn test_sqlx_auto_created_table_is_cursor_readable() {
     assert!(v["locked_until"].is_null());
 }
 
+// A DATETIME cursor column is now readable on SQLite (the projection casts it to TEXT),
+// so the cursor value round-trips as text while `WHERE`/`ORDER BY` still compare the raw
+// column. Pin that resume neither skips nor re-emits rows.
+#[tokio::test]
+async fn test_sqlx_cursor_reader_datetime_cursor_column_resumes() {
+    sqlx::any::install_default_drivers();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("dtcursor.db");
+    let url = sqlite_url(&path);
+    drop(tokio::fs::File::create(&path).await.unwrap());
+    let pool = AnyPool::connect(&url).await.unwrap();
+    sqlx::query("CREATE TABLE events (id INTEGER PRIMARY KEY, ts DATETIME, note TEXT)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    for (i, ts) in [
+        "2026-08-16 10:00:00",
+        "2026-08-16 10:00:01",
+        "2026-08-16 10:00:02",
+        "2026-08-16 10:00:03",
+    ]
+    .iter()
+    .enumerate()
+    {
+        sqlx::query("INSERT INTO events (id, ts, note) VALUES (?, ?, ?)")
+            .bind((i + 1) as i64)
+            .bind(*ts)
+            .bind(format!("n{i}"))
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    let config = SqlxConfig {
+        url,
+        table: "events".to_string(),
+        cursor_column: Some("ts".to_string()),
+        cursor_id: Some("dt-1".to_string()),
+        ..Default::default()
+    };
+    let mut reader = SqlxCursorReader::new(&config).await.unwrap();
+    let b1 = reader.receive_batch(2).await.unwrap();
+    assert_eq!(b1.messages.len(), 2);
+    (b1.commit)(vec![MessageDisposition::Ack; 2]).await.unwrap();
+
+    let b2 = reader.receive_batch(2).await.unwrap();
+    let notes: Vec<String> = b2
+        .messages
+        .iter()
+        .map(|m| serde_json::from_slice::<serde_json::Value>(&m.payload).unwrap()["note"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(notes, vec!["n2", "n3"], "resume must continue, not repeat or skip");
+    (b2.commit)(vec![MessageDisposition::Ack; 2]).await.unwrap();
+
+    let b3 = reader.receive_batch(2).await.unwrap();
+    assert!(b3.messages.is_empty(), "drained");
+}
+
 #[tokio::test]
 async fn test_sqlx_auto_create_rejects_tokens() {
     let (_dir, url) = setup_db_file().await;

--- a/src/endpoints/sqlx/tests.rs
+++ b/src/endpoints/sqlx/tests.rs
@@ -1009,6 +1009,50 @@ async fn test_sqlx_multicolumn_batch() {
     }
 }
 
+// Regression (issue #71): a table written by the publisher with `auto_create_table` must be
+// readable by this library's own cursor reader. The generated DDL declares `locked_until`/
+// `created_at` as DATETIME, which the `Any` driver refuses to decode, so `SELECT *` failed the
+// whole read. The projection now casts those columns to TEXT.
+#[tokio::test]
+async fn test_sqlx_auto_created_table_is_cursor_readable() {
+    sqlx::any::install_default_drivers();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("roundtrip.db");
+    let url = sqlite_url(&path);
+    drop(tokio::fs::File::create(&path).await.unwrap());
+
+    let config = SqlxConfig {
+        url: url.clone(),
+        table: "orders".to_string(),
+        auto_create_table: true,
+        ..Default::default()
+    };
+    let publisher = SqlxPublisher::new(&config).await.unwrap();
+    publisher
+        .send_batch(
+            (1..=3)
+                .map(|i| CanonicalMessage::new(format!("row{i}").into_bytes(), None))
+                .collect(),
+        )
+        .await
+        .unwrap();
+
+    let read_config = SqlxConfig {
+        url,
+        table: "orders".to_string(),
+        cursor_column: Some("id".to_string()),
+        ..Default::default()
+    };
+    let mut reader = SqlxCursorReader::new(&read_config).await.unwrap();
+    let batch = reader.receive_batch(10).await.unwrap();
+    assert_eq!(batch.messages.len(), 3);
+    let v: serde_json::Value = serde_json::from_slice(&batch.messages[0].payload).unwrap();
+    assert_eq!(v["id"], 1);
+    // The DATETIME columns survive as strings rather than aborting the read.
+    assert!(v.get("created_at").is_some());
+    assert!(v["locked_until"].is_null());
+}
+
 #[tokio::test]
 async fn test_sqlx_auto_create_rejects_tokens() {
     let (_dir, url) = setup_db_file().await;

--- a/src/endpoints/sqlx/tests.rs
+++ b/src/endpoints/sqlx/tests.rs
@@ -1102,9 +1102,18 @@ async fn test_sqlx_cursor_reader_datetime_cursor_column_resumes() {
     let notes: Vec<String> = b2
         .messages
         .iter()
-        .map(|m| serde_json::from_slice::<serde_json::Value>(&m.payload).unwrap()["note"].as_str().unwrap().to_string())
+        .map(|m| {
+            serde_json::from_slice::<serde_json::Value>(&m.payload).unwrap()["note"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
         .collect();
-    assert_eq!(notes, vec!["n2", "n3"], "resume must continue, not repeat or skip");
+    assert_eq!(
+        notes,
+        vec!["n2", "n3"],
+        "resume must continue, not repeat or skip"
+    );
     (b2.commit)(vec![MessageDisposition::Ack; 2]).await.unwrap();
 
     let b3 = reader.receive_batch(2).await.unwrap();

--- a/src/endpoints/structural/fanout.rs
+++ b/src/endpoints/structural/fanout.rs
@@ -101,6 +101,11 @@ impl MessagePublisher for FanoutPublisher {
         }
     }
 
+    /// Ordered if any leg is: a fanout is only as order-tolerant as its strictest sink.
+    fn requires_ordered_publish(&self) -> bool {
+        self.publishers.iter().any(|p| p.requires_ordered_publish())
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/endpoints/structural/request.rs
+++ b/src/endpoints/structural/request.rs
@@ -99,6 +99,10 @@ impl MessagePublisher for RequestForwardPublisher {
         self.request.status().await
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.request.requires_ordered_publish() || self.forward.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/endpoints/structural/switch.rs
+++ b/src/endpoints/structural/switch.rs
@@ -127,6 +127,14 @@ impl MessagePublisher for SwitchPublisher {
         }
     }
 
+    /// Ordered if any branch is: batches for a given branch must stay in source order.
+    fn requires_ordered_publish(&self) -> bool {
+        self.cases
+            .values()
+            .chain(self.default.iter())
+            .any(|p| p.requires_ordered_publish())
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/buffer.rs
+++ b/src/middleware/buffer.rs
@@ -352,6 +352,10 @@ impl MessagePublisher for BufferPublisher {
         self.core.inner.flush().await
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.core.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/compression.rs
+++ b/src/middleware/compression.rs
@@ -87,6 +87,10 @@ impl MessagePublisher for CompressionPublisher {
         }
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/cookie_jar.rs
+++ b/src/middleware/cookie_jar.rs
@@ -340,6 +340,10 @@ impl MessagePublisher for CookieJarPublisher {
         }
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/delay.rs
+++ b/src/middleware/delay.rs
@@ -91,6 +91,10 @@ impl MessagePublisher for DelayPublisher {
         self.inner.send_batch(messages).await
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/dlq.rs
+++ b/src/middleware/dlq.rs
@@ -311,6 +311,10 @@ impl MessagePublisher for DlqPublisher {
         }
     }
 
+    /// Deliberately follows `inner` only, not the DLQ. An order-sensitive DLQ behind an
+    /// unordered sink would sequence *every* batch — paying the primary sink's whole
+    /// concurrency factor — to order a sparse, failure-only side channel. When the gate
+    /// is on, the DLQ send is inside this `send_batch` and is sequenced with it anyway.
     fn requires_ordered_publish(&self) -> bool {
         self.inner.requires_ordered_publish()
     }

--- a/src/middleware/dlq.rs
+++ b/src/middleware/dlq.rs
@@ -311,6 +311,10 @@ impl MessagePublisher for DlqPublisher {
         }
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/encryption.rs
+++ b/src/middleware/encryption.rs
@@ -90,6 +90,10 @@ impl MessagePublisher for EncryptionPublisher {
         }
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/limiter.rs
+++ b/src/middleware/limiter.rs
@@ -165,6 +165,10 @@ impl MessagePublisher for LimiterPublisher {
         self.inner.send_batch(messages).await
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/metrics.rs
+++ b/src/middleware/metrics.rs
@@ -83,6 +83,10 @@ impl MessagePublisher for MetricsPublisher {
         Ok(result)
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/random_panic.rs
+++ b/src/middleware/random_panic.rs
@@ -208,6 +208,10 @@ impl MessagePublisher for RandomPanicPublisher {
         }
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/retry.rs
+++ b/src/middleware/retry.rs
@@ -199,6 +199,10 @@ impl MessagePublisher for RetryPublisher {
         }
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/middleware/transform/mod.rs
+++ b/src/middleware/transform/mod.rs
@@ -134,6 +134,10 @@ impl MessagePublisher for TransformPublisher {
         self.inner.flush().await
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -143,7 +143,9 @@ pub struct RouteOptions {
     pub description: String,
     /// (Optional) Number of concurrent processing tasks for this route. While it improves throughput for high-latency
     /// handlers, it adds synchronization overhead for ordered commits and may lead to out-of-order processing
-    /// in the handler. Defaults to 1.
+    /// in the handler. Above 1, whole batches may also reach the sink out of source order (rows keep their order
+    /// within a batch) unless the sink declares itself order-sensitive, as `file` does.
+    /// Defaults to 1.
     #[serde(default = "default_concurrency")]
     #[cfg_attr(feature = "schema", schemars(range(min = 1)))]
     pub concurrency: usize,

--- a/src/plugin/middleware.rs
+++ b/src/plugin/middleware.rs
@@ -359,6 +359,10 @@ impl MessagePublisher for PluginMiddlewarePublisher {
         self.inner.flush().await
     }
 
+    fn requires_ordered_publish(&self) -> bool {
+        self.inner.requires_ordered_publish()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -41,6 +41,12 @@ pub use crate::extensions::{
 pub enum RouteOutcome {
     /// The source drained and the route exited on its own — `exit_on_empty`
     /// or an exhausted stream. The job succeeded.
+    ///
+    /// "Completed" describes the *route*, not the data: a run whose sink rejected
+    /// messages permanently with no `dlq` middleware configured still completes, with
+    /// the dropped count and cause reported in [`EndpointStatus::error`] via
+    /// [`RouteHandle::status`]. A caller that must distinguish a clean run from a
+    /// dirty one has to read that field too.
     Completed,
     /// Terminated by an explicit `stop()` or shutdown signal.
     Stopped,
@@ -437,11 +443,26 @@ async fn send_batch_and_commit(
     commit_tasks: &mut JoinSet<()>,
     scratch: &mut BatchScratch,
     drops: Option<&Arc<RwLock<DropReport>>>,
+    ticket: Option<OrderTicket>,
 ) -> anyhow::Result<()> {
     let batch_len = messages.len();
     scratch.fill_from(&messages);
 
-    match publisher.send_batch(messages).await {
+    // An order-sensitive sink admits one send at a time, in source order. Everything
+    // above and below this call stays concurrent.
+    let sent = {
+        let _release = match ticket {
+            Some(mut ticket) => {
+                if let Some(prev) = ticket.prev.take() {
+                    let _ = prev.await;
+                }
+                Some(ticket)
+            }
+            None => None,
+        };
+        publisher.send_batch(messages).await
+    };
+    match sent {
         Ok(SentBatch::Ack) => {
             for id in scratch.message_ids.iter() {
                 if scratch.request_ids.contains(id) {
@@ -1241,6 +1262,8 @@ impl Route {
                         &mut commit_tasks,
                         &mut batch_scratch,
                         drops,
+                        // The sequential runner sends one batch at a time already.
+                        None,
                     )
                     .await
                     {
@@ -1310,10 +1333,28 @@ impl Route {
             let _ = tx.send(()).await;
         }
         let (err_tx, err_rx) = bounded(1); // For critical, route-stopping errors
-                                           // channel capacity is measured in batches, not messages
+
+        // --- Publish Dispatch ---
+        // Workers normally send concurrently, which lets whole batches reach the sink out of
+        // source order. A sink that is an ordered log (the file sink) declares
+        // `requires_ordered_publish()` and gets a per-batch [`OrderTicket`] instead, which
+        // sequences the `send_batch` call itself. Only that call: batch prep, disposition
+        // mapping and commits still run across the whole pool, which is why an ordered
+        // route measures within noise of an unordered one.
+        let ordered_publish = publisher.requires_ordered_publish();
+        if ordered_publish {
+            debug!(
+                "Route '{}' publishes to an order-sensitive sink: sends are sequenced.",
+                name
+            );
+        }
+        // channel capacity is measured in batches, not messages
         let work_capacity = self.options.concurrency;
-        let (work_tx, work_rx) =
-            bounded::<(Vec<crate::CanonicalMessage>, BatchCommitFunc)>(work_capacity);
+        let (work_tx, work_rx) = bounded::<(
+            Vec<crate::CanonicalMessage>,
+            BatchCommitFunc,
+            Option<OrderTicket>,
+        )>(work_capacity);
         // --- Commit Dispatch ---
         // Cumulative-ack brokers (Kafka/AMQP) must commit in order, so their commits
         // are funnelled through a single sequencer to prevent data loss. Individual-ack
@@ -1343,7 +1384,7 @@ impl Route {
                 debug!("Starting worker {}", i);
                 let mut batch_scratch = BatchScratch::with_capacity(batch_size);
                 let mut since_yield = 0usize;
-                while let Ok((messages, commit_func)) = work_rx_clone.recv().await {
+                while let Ok((messages, commit_func, ticket)) = work_rx_clone.recv().await {
                     let batch_len = messages.len();
                     if let Err(err) = send_batch_and_commit(
                         &publisher,
@@ -1356,6 +1397,7 @@ impl Route {
                         &mut commit_tasks,
                         &mut batch_scratch,
                         drops.as_ref(),
+                        ticket,
                     )
                     .await
                     {
@@ -1376,6 +1418,9 @@ impl Route {
         }
 
         let mut seq_counter = 0u64;
+        // Tail of the publish-ordering chain: what the *next* batch waits on. `None`
+        // while the sink tolerates unordered sends.
+        let mut prev_publish: Option<tokio::sync::oneshot::Receiver<()>> = None;
         // Messages enqueued to workers since the last cooperative yield (see YIELD_EVERY_MSGS).
         let mut since_yield = 0usize;
         // Holds an error that caused the loop to break, to be returned after graceful shutdown.
@@ -1456,16 +1501,26 @@ impl Route {
                     let seq = seq_counter;
                     let batch_len = messages.len();
                     let wrapped_commit = commit_router.wrap(commit, seq);
+                    let ticket = ordered_publish.then(|| {
+                        let (release, next_prev) = tokio::sync::oneshot::channel();
+                        let ticket = OrderTicket {
+                            prev: prev_publish.take(),
+                            _release: release,
+                        };
+                        prev_publish = Some(next_prev);
+                        ticket
+                    });
 
-                    match work_tx.send((messages, wrapped_commit)).await {
+                    match work_tx.send((messages, wrapped_commit, ticket)).await {
                         Ok(()) => {
                             seq_counter += 1;
                         }
                         Err(e) => {
                             warn!("Work channel closed, cannot process more messages concurrently. Shutting down.");
                             // Recover the moved tuple so we can invoke the wrapped commit
-                            // and resolve the batch with a NACK.
-                            let (msgs_back, wrapped_commit_back) = e.into_inner();
+                            // and resolve the batch with a NACK. Dropping the ticket
+                            // releases whatever batch is queued behind this one.
+                            let (msgs_back, wrapped_commit_back, _) = e.into_inner();
                             let _ = (wrapped_commit_back)(vec![crate::traits::MessageDisposition::Nack; msgs_back.len()]).await;
                             break;
                         }
@@ -1721,6 +1776,16 @@ fn wrap_commit(
             }
         })
     })
+}
+
+/// Hands the right to call `send_batch` from one batch to the next when the sink
+/// declares [`MessagePublisher::requires_ordered_publish`]. `prev` resolves once the
+/// preceding batch's send returned (or its worker went away); dropping `_release` lets
+/// the batch behind it in. Only the `send_batch` call is serialised — per-batch prep,
+/// disposition mapping and commits still run concurrently across the worker pool.
+struct OrderTicket {
+    prev: Option<tokio::sync::oneshot::Receiver<()>>,
+    _release: tokio::sync::oneshot::Sender<()>,
 }
 
 /// Routes batch commits either through the ordered sequencer (cumulative-ack
@@ -2245,6 +2310,158 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_concurrent_route_commits_are_ordered_and_non_overlapping() {
         assert_route_commits_are_ordered_and_non_overlapping(4).await;
+    }
+
+    #[derive(Debug, Default)]
+    struct PublishObservation {
+        /// Batch sequence numbers in the order their `send_batch` completed.
+        arrived: Mutex<Vec<u64>>,
+        active: std::sync::atomic::AtomicUsize,
+        max_active: std::sync::atomic::AtomicUsize,
+    }
+
+    #[derive(Debug)]
+    struct OrderedPublishMiddlewareFactory {
+        observation: Arc<PublishObservation>,
+        /// Drives the wrapped publisher's `requires_ordered_publish()`, so one factory
+        /// exercises both an order-sensitive sink (file, object_store) and a plain one.
+        requires_order: bool,
+    }
+
+    struct OrderedPublishTracker {
+        inner: Box<dyn MessagePublisher>,
+        observation: Arc<PublishObservation>,
+        requires_order: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl CustomMiddlewareFactory for OrderedPublishMiddlewareFactory {
+        async fn apply_publisher(
+            &self,
+            publisher: Box<dyn MessagePublisher>,
+            _route_name: &str,
+            _config: &serde_json::Value,
+        ) -> anyhow::Result<Box<dyn MessagePublisher>> {
+            Ok(Box::new(OrderedPublishTracker {
+                inner: publisher,
+                observation: Arc::clone(&self.observation),
+                requires_order: self.requires_order,
+            }))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MessagePublisher for OrderedPublishTracker {
+        fn requires_ordered_publish(&self) -> bool {
+            self.requires_order
+        }
+
+        async fn send_batch(
+            &self,
+            messages: Vec<crate::CanonicalMessage>,
+        ) -> Result<SentBatch, PublisherError> {
+            let seq = messages
+                .first()
+                .and_then(|message| message.get_payload_str().parse::<u64>().ok())
+                .expect("tracking test expects numeric payloads");
+            let active_now = self.observation.active.fetch_add(1, Ordering::SeqCst) + 1;
+            let _ = self.observation.max_active.fetch_update(
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+                |current| (active_now > current).then_some(active_now),
+            );
+            // Later batches are faster, so unsequenced sends land in reverse order.
+            tokio::time::sleep(Duration::from_millis(
+                10 * (6u64.saturating_sub(seq.min(6))),
+            ))
+            .await;
+            let result = self.inner.send_batch(messages).await;
+            self.observation.arrived.lock().unwrap().push(seq);
+            self.observation.active.fetch_sub(1, Ordering::SeqCst);
+            result
+        }
+
+        async fn flush(&self) -> anyhow::Result<()> {
+            self.inner.flush().await
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    async fn run_publish_order_route(requires_order: bool) -> Arc<PublishObservation> {
+        let unique_id = fast_uuid_v7::gen_id().to_string();
+        let tracking_name = format!("track_publish_{}", unique_id);
+        let in_topic = format!("publish_order_in_{}", unique_id);
+        let observation = Arc::new(PublishObservation::default());
+
+        register_middleware_factory(
+            &tracking_name,
+            Arc::new(OrderedPublishMiddlewareFactory {
+                observation: Arc::clone(&observation),
+                requires_order,
+            }),
+        )
+        .unwrap();
+
+        let input = Endpoint::new_memory(&in_topic, 32);
+        let output = Endpoint::new(EndpointType::Null).add_middleware(Middleware::Custom {
+            name: tracking_name,
+            config: serde_json::Value::Null,
+        });
+
+        let route = Route::new(input.clone(), output)
+            .with_concurrency(4)
+            .with_batch_size(1);
+
+        let input_channel = input.channel().unwrap();
+        let messages = (0..6)
+            .map(|seq| crate::CanonicalMessage::from(seq.to_string()))
+            .collect();
+        input_channel.fill_messages(messages).await.unwrap();
+        input_channel.close();
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            route.run_until_err("publish_order_test", None, None),
+        )
+        .await
+        .expect("Route should not hang while draining finite input")
+        .expect("Route should complete without errors");
+
+        observation
+    }
+
+    // Regression (issue #71): with `concurrency > 1` the workers used to call `send_batch`
+    // in parallel, so whole batches reached the sink out of source order — silently
+    // shuffling a file/object_store export. A sink that declares
+    // `requires_ordered_publish()` now gets its sends sequenced.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_order_sensitive_sink_receives_batches_in_source_order() {
+        let observation = run_publish_order_route(true).await;
+
+        assert_eq!(
+            *observation.arrived.lock().unwrap(),
+            vec![0, 1, 2, 3, 4, 5],
+            "An order-sensitive sink must see batches in source order",
+        );
+        assert_eq!(
+            observation.max_active.load(Ordering::SeqCst),
+            1,
+            "Sequenced sends must never overlap",
+        );
+    }
+
+    // The default stays unordered so concurrent sinks keep their throughput: batches may
+    // arrive in any order, but every one of them must arrive exactly once.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_unordered_sink_still_receives_every_batch() {
+        let observation = run_publish_order_route(false).await;
+
+        let mut arrived = observation.arrived.lock().unwrap().clone();
+        arrived.sort_unstable();
+        assert_eq!(arrived, vec![0, 1, 2, 3, 4, 5]);
     }
 
     /// Drives a route whose consumer reports `commit_requires_order() == false`

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -442,6 +442,36 @@ pub trait MessagePublisher: Send + Sync + 'static {
             ..Default::default()
         }
     }
+
+    /// Whether batches must reach this publisher in the order the source produced
+    /// them. The publisher-side counterpart to
+    /// [`MessageConsumer::commit_requires_order`].
+    ///
+    /// Defaults to `false`: with `concurrency > 1` the route's workers call
+    /// `send_batch` in parallel, so whole batches can land at the sink out of source
+    /// order (rows keep their order *within* a batch). For an unkeyed SQL, Mongo or
+    /// ClickHouse insert that is meaningless, and serialising sends would cost
+    /// throughput for nothing.
+    ///
+    /// Override to `true` when the destination *is* an ordered log and shuffling it
+    /// corrupts the result — `file` does. The route then admits one batch at a time
+    /// into `send_batch`, in sequence; everything around that call still runs across
+    /// the worker pool, so an ordered route measures within noise of an unordered one.
+    ///
+    /// Only override it where the *cost* is also low, which means a sink whose
+    /// `send_batch` is already serialised internally (the file sink holds a write lock
+    /// for the whole batch). Sequencing a sink that ends in a network round trip costs
+    /// it the whole concurrency factor: one batch in flight instead of N.
+    ///
+    /// Note for keyed transports: Kafka preserves order per partition only if batches
+    /// are *produced* in order, so a route with `partition_key` and `concurrency > 1`
+    /// can publish two batches sharing a key in either order. Kafka leaves this `false`
+    /// (global ordering would serialise an inherently parallel sink); set
+    /// `concurrency: 1` if per-key order matters.
+    fn requires_ordered_publish(&self) -> bool {
+        false
+    }
+
     fn as_any(&self) -> &dyn Any;
 }
 
@@ -472,6 +502,10 @@ impl<T: MessagePublisher + ?Sized> MessagePublisher for Arc<T> {
 
     async fn status(&self) -> EndpointStatus {
         (**self).status().await
+    }
+
+    fn requires_ordered_publish(&self) -> bool {
+        (**self).requires_ordered_publish()
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -506,6 +540,10 @@ impl<T: MessagePublisher + ?Sized> MessagePublisher for Box<T> {
 
     async fn status(&self) -> EndpointStatus {
         (**self).status().await
+    }
+
+    fn requires_ordered_publish(&self) -> bool {
+        (**self).requires_ordered_publish()
     }
 
     fn as_any(&self) -> &dyn Any {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

<!-- Describe the tests you ran and how to verify your changes -->

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if needed)
- [ ] No new warnings generated
- [ ] Tests added/updated for new functionality
- [ ] All tests pass locally

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Related to #

## Additional Notes

<!-- Any additional information that reviewers should know -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Ordered publishing is now preserved for order-sensitive destinations, even when routes use concurrency or buffering.
  - Ordering requirements now flow through routing, middleware, fan-out, switching, and request forwarding.
  - Improved SQLite cursor compatibility, including safer handling of `DATETIME` fields and reliable checkpoint resumption.

- **Bug Fixes**
  - Fixed potential out-of-order file delivery during concurrent processing.
  - Prevented skipped or duplicated records when resuming SQLite cursor reads.

- **Documentation**
  - Clarified ordering guarantees, concurrency behavior, and route completion status.

- **Release**
  - Updated version to 0.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->