### PR TITLE
fix object store sorting issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "fast-uuid-v7"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d7a30239eba18ae6a60dc3c3df98af18f00bba69d2b1d5f2816a831e83bff3"
+checksum = "dc759201eb9b09178fb2174087a451d19fd46a8b8b4f5f6103de83b9f5949f52"
 dependencies = [
  "rand 0.10.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ version = "0.4.2"
 anyhow = "1.0"
 async-trait = "0.1"
 bytes = "1"
-fast-uuid-v7 = "0.1.8"
+fast-uuid-v7 = "0.1.9"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["raw_value"] }
 serde_yaml_ng = "0.10"

--- a/docs/DELIVERY.md
+++ b/docs/DELIVERY.md
@@ -22,7 +22,7 @@ sink writes data.
 | MongoDB | `id_field` set to a payload field or replay-stable template such as `${metadata:mqb.id}` |
 | PostgreSQL / SQLite | `sqlx.insert_query` uses a unique key with `ON CONFLICT` |
 | MySQL / MariaDB | `sqlx.insert_query` uses a unique key with `ON DUPLICATE KEY` |
-| File / object store | `idempotency: true` with a replayable Kafka or Postgres CDC source |
+| File / object store | `idempotency: true` with a replayable Kafka, Postgres CDC, SQL cursor, MongoDB CDC or file source |
 
 For a source without stable identity, derive one once and consume it at the sink:
 
@@ -143,7 +143,7 @@ one identity to every message missing the field, so it is dropped instead.
 | `mongodb` | Unique `_id` index; dup-key (11000) is treated as an idempotent success | `id_field` |
 | `sqlx` (PostgreSQL / MySQL / SQLite) | The table's own `UNIQUE`/`PRIMARY KEY` | `ON CONFLICT` / `ON DUPLICATE KEY` in `insert_query` |
 | `clickhouse` | `ReplacingMergeTree` collapses at merge time | Table DDL — no `mq-bridge` config |
-| `file`, `object_store` | Deterministic part names + covered-range recovery | `idempotency: true` (needs a replayable source) |
+| `file`, `object_store` | Deterministic, sortable part names + covered-range recovery | `idempotency: true` (needs a replayable source) |
 | `kafka` | `enable.idempotence` dedups **producer retries within one session** — this is *not* exactly-once semantics | On by default |
 | `nats`, `amqp`, `mqtt`, `redis_streams`, `aws`, `ibm_mq`, `zeromq` | None | Deduplicate at the next consumer instead |
 
@@ -359,6 +359,13 @@ but before the branch's downstream send committed, the replay hits a duplicate k
 
 ### Files & object storage — `idempotency`
 
+> **Check first whether you need any of this.** If your records already carry a business key — an
+> `id` field in the payload, or `mqb.id` from the [`id` middleware](#giving-a-source-an-identity) —
+> then a key-addressed sink (Mongo `id_field`, SQL `ON CONFLICT`) already gives you effective
+> exactly-once, and the order objects happen to land in does not matter. Positional naming below is
+> for the case where the *sink itself* has to recognise a replay, or where a downstream reader
+> depends on replay **order**. Turning it on when you do not need it only adds restrictions.
+
 A filesystem has no unique constraint, so the `file` and `object_store` sinks get replay safety a
 different way: **deterministic names plus covered-range recovery**. Set `idempotency: true` and the
 sink stops writing UUID-named objects. Instead it groups each batch into runs of consecutive source
@@ -371,7 +378,7 @@ kafka_to_s3:
   output:
     object_store:
       url: "s3://my-bucket/orders"
-      idempotency: true          # → s3://my-bucket/orders/part-orders-0-0-1023.jsonl
+      idempotency: true          # → part-orders-<partition>-<start>-<end>.jsonl (zero-padded)
 ```
 
 On startup the sink lists what is already there, parses the ranges out of the part names, and drops
@@ -381,13 +388,58 @@ checkpoint protocol. Local files stage to a temp name, `fsync`, then `rename` (a
 filesystem); object stores have no atomic rename, so a single PUT under the final name *is* the
 commit.
 
-This needs a replayable source position, which today means **Kafka** (topic/partition/offset) or
-**`postgres_cdc`** (commit LSN plus in-transaction ordinal; `sqlx` with `publication` maps onto the
-same consumer). A route with an idempotent output turns `source_metadata` on for its input
-automatically; set it explicitly only when you want the `mqb.src.*` keys for something else. Any
-other input is rejected when the route starts. NATS, AMQP and MongoDB CDC also accept
-`source_metadata` and emit provenance keys, but a subject or routing key is not a replayable offset,
-so they cannot drive an idempotent sink.
+This needs a replayable source position. Today that means:
+
+| Source | Position | Restriction |
+| --- | --- | --- |
+| `kafka` | topic / partition / offset | — |
+| `postgres_cdc` | commit LSN + in-transaction ordinal | `sqlx` with `publication` maps onto the same consumer |
+| `mongodb` | cluster time + ordinal; the initial snapshot uses its `_id` scan index | `capture_new` / `capture_all` only — `consumer` and `snapshot` have no position |
+| `file` | record index within the file | all modes; only `consume` deduplicates across runs (see below) |
+| `sqlx` | the `cursor_column` value | cursor polling only; the column must be a unique, non-negative integer |
+
+A route with an idempotent output turns `source_metadata` on for its input automatically; set it
+explicitly only when you want the `mqb.src.*` keys for something else. Any other input is rejected
+when the route starts. NATS and AMQP also accept `source_metadata` and emit provenance keys, but a
+subject or routing key is not a replayable offset, so they cannot drive an idempotent sink.
+
+**Without `idempotency: true`, an `object_store` sink names objects in write order**, and key order
+is the only order a bucket has. At `concurrency: 1` that is source order; above it the name is minted
+inside the worker pool, so it is arrival order, and replaying a change stream through the bucket can
+reorder updates to the same key. The route logs a warning when it starts in that configuration.
+
+**Numbers inside a part name are zero-padded** so that ASCII sort equals numeric sort — a bucket is
+listed lexicographically and that listing order *is* the replay order. A bucket written by a version
+before this padding contains unpadded names; the two forms do not sort correctly against each other,
+so do not mix them in one prefix.
+
+**MongoDB `capture_all`** reads the collection, then streams changes. Both phases are numbered into
+the key so the snapshot always sorts ahead of the changes; a change can never replay before the
+document it modifies. The snapshot does not resume across runs — it re-scans from the start — but the
+numbering is deterministic, so a restart reproduces the same names and the covered-range recovery
+skips them. The exception is inserts or deletes landing in the collection between the two runs: those
+shift the numbering, and some documents are then written twice.
+
+**The `sqlx` cursor source** uses the `cursor_column` value itself as the position — the same shape
+Kafka Connect's S3 sink gives a Kafka offset. That only works for a unique, non-negative integer
+column: a text cursor pages fine but has no contiguous numeric order, and a repeated value would
+resolve two rows to one position and drop one of them. The reader rejects both at read time rather
+than naming records wrongly. Consecutive ids coalesce into one part file; gaps split it.
+
+**The `file` source** numbers records by their index in the file, not their byte offset (byte offsets
+are not consecutive, so every record would become its own part).
+
+That index repeats across runs only in `consume` mode, which always reads from byte 0 — and repeating
+is the point: a re-read produces the same names, so the sink recognises them as already covered and
+writes nothing. `subscribe` starts at the current end of the file and `group_subscribe` resumes at a
+stored byte offset, so their index restarts at 0 over records an earlier run already numbered. Those
+two modes therefore carry a **run epoch** in the object name.
+
+The epoch keeps names distinct and keeps runs in order (a later run reads later records, so its
+objects sort after the earlier run's). What it does not give you is deduplication across a restart:
+records re-read after a crash are written again under new names. That is ordinary at-least-once, and
+it is the honest guarantee for a source with no durable per-record position — these modes are
+allowed, not rejected, because that guarantee is fine for plenty of pipelines.
 
 For the `file` sink, `idempotency: true` changes what `path` means: it is the directory that receives
 the part files, not the file that is appended to. The sink creates it on startup, so pointing it at an

--- a/mq-bridge.schema.json
+++ b/mq-bridge.schema.json
@@ -1012,7 +1012,7 @@
           "default": "normal"
         },
         "idempotency": {
-          "description": "Write replay-safe source ranges as immutable part files under this directory.\nRequires a source that stamps a replayable position: kafka, postgres_cdc, mongodb CDC or file.",
+          "description": "Write replay-safe source ranges as immutable part files under this directory.\nRequires a source that stamps a replayable position: kafka, postgres_cdc, mongodb CDC, sqlx or file.",
           "type": "boolean",
           "default": false
         },

--- a/mq-bridge.schema.json
+++ b/mq-bridge.schema.json
@@ -1012,13 +1012,18 @@
           "default": "normal"
         },
         "idempotency": {
-          "description": "Write replay-safe source ranges as immutable part files under this directory.\nRequires Kafka source metadata or postgres_cdc commit LSN plus transaction ordinal metadata.",
+          "description": "Write replay-safe source ranges as immutable part files under this directory.\nRequires a source that stamps a replayable position: kafka, postgres_cdc, mongodb CDC or file.",
           "type": "boolean",
           "default": false
         },
         "path": {
           "description": "Path to the file, or to the directory holding the part files when `idempotency` is true.",
           "type": "string"
+        },
+        "source_metadata": {
+          "description": "(Consumer only) Include authoritative `mqb.src.file_*` source positions; only `consume` mode reproduces them across restarts. Defaults to false.",
+          "type": "boolean",
+          "default": false
         }
       },
       "anyOf": [
@@ -3216,6 +3221,11 @@
             "string",
             "null"
           ]
+        },
+        "source_metadata": {
+          "description": "(Consumer only) Include authoritative `mqb.src.sqlx_*` source positions; `cursor_column` must then be a unique integer. Defaults to false.",
+          "type": "boolean",
+          "default": false
         },
         "table": {
           "description": "The table to interact with.",

--- a/python/mq-bridge-py/mq_bridge/config.pyi
+++ b/python/mq-bridge-py/mq_bridge/config.pyi
@@ -154,6 +154,7 @@ class FileConfig(TypedDict, total=False):
     format: FileFormat
     idempotency: bool
     path: Required[str]
+    source_metadata: bool
 
 
 class GrpcConfig(TypedDict, total=False):
@@ -476,6 +477,7 @@ class SqlxConfig(TypedDict, total=False):
     select_query: Optional[str]
     shared: Optional[bool]
     slot_name: Optional[str]
+    source_metadata: bool
     table: Required[str]
     test_before_acquire: Optional[bool]
     tls: TlsConfig

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -2013,6 +2013,13 @@ pub struct FileConsumer {
     /// A live tail keeps waiting for the file to appear; a drain (`exit_on_empty`)
     /// cannot, so it fails with this instead of blocking forever.
     startup_open_error: Option<String>,
+    /// Stamp `mqb.src.file_*` so an idempotent sink can name records in source order.
+    source_metadata: bool,
+    /// Index of the next record in this file.
+    next_record: u64,
+    /// Set only for the modes that do not start at byte 0, so their record indexes cannot
+    /// collide with a previous run's. `None` for `consume`, whose names must repeat.
+    run_epoch: Option<u64>,
     exit_on_empty: bool,
 }
 
@@ -2022,6 +2029,9 @@ impl FileConsumer {
             backend,
             path: String::new(),
             startup_open_error: None,
+            source_metadata: false,
+            next_record: 0,
+            run_epoch: None,
             exit_on_empty: false,
         }
     }
@@ -2031,6 +2041,22 @@ impl FileConsumer {
         let mut consumer = Self::new_backend(config).await?;
         consumer.path = config.path.clone();
         consumer.startup_open_error = startup_open_error;
+        consumer.source_metadata = config.source_metadata;
+        // `consume` always reads from byte 0, so its record index is reproducible and two
+        // runs deliberately produce the same names — that is what makes the sink idempotent.
+        // `subscribe` starts at the current end and `group_subscribe` resumes at a stored
+        // byte offset, so their index restarts at 0 over records a previous run already
+        // numbered. Without an epoch those names would collide and the sink would discard
+        // the new records as already-covered; with one they stay distinct and ordered, at
+        // the cost of cross-restart deduplication.
+        consumer.run_epoch = (config.source_metadata
+            && !matches!(&config.mode, None | Some(FileConsumerMode::Consume { .. })))
+        .then(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0)
+        });
         Ok(consumer)
     }
 
@@ -2344,6 +2370,37 @@ impl MessageConsumer for FileConsumer {
     // a cumulative byte offset (the max acked `file_offset`), so out-of-order
     // commits could advance the offset past un-acked messages and lose them.
     async fn receive_batch(&mut self, max_messages: usize) -> Result<ReceivedBatch, ConsumerError> {
+        let mut batch = self.receive_batch_inner(max_messages).await?;
+        if self.source_metadata {
+            for message in &mut batch.messages {
+                message
+                    .metadata
+                    .insert("mqb.src.file_path".to_string(), self.path.clone());
+                message.metadata.insert(
+                    "mqb.src.file_record".to_string(),
+                    self.next_record.to_string(),
+                );
+                if let Some(epoch) = self.run_epoch {
+                    message
+                        .metadata
+                        .insert("mqb.src.file_epoch".to_string(), epoch.to_string());
+                }
+                self.next_record += 1;
+            }
+        }
+        Ok(batch)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl FileConsumer {
+    async fn receive_batch_inner(
+        &mut self,
+        max_messages: usize,
+    ) -> Result<ReceivedBatch, ConsumerError> {
         // The path was unopenable at startup. A live tail waits for it (rotation,
         // a writer that hasn't created it yet), but a drain has nothing to wait
         // for, so re-probe and fail rather than block forever on a typo'd path.
@@ -2565,10 +2622,6 @@ impl MessageConsumer for FileConsumer {
                 })
             }
         }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 }
 

--- a/src/endpoints/file/mod.rs
+++ b/src/endpoints/file/mod.rs
@@ -19,7 +19,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::io::Seek;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, Weak};
 use std::time::{Duration, SystemTime};
 use tokio::fs::{self, File, OpenOptions};
@@ -2023,6 +2023,25 @@ pub struct FileConsumer {
     exit_on_empty: bool,
 }
 
+/// Hands out a strictly increasing run epoch. Seeded from wall-clock millis so epochs still
+/// sort across process restarts, but never repeats or goes backwards within one process —
+/// consumers built in the same millisecond, or across a clock step back, stay distinct.
+fn next_run_epoch() -> u64 {
+    static LAST: AtomicU64 = AtomicU64::new(0);
+    let now = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let mut last = LAST.load(Ordering::Relaxed);
+    loop {
+        let epoch = now.max(last + 1);
+        match LAST.compare_exchange_weak(last, epoch, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => return epoch,
+            Err(observed) => last = observed,
+        }
+    }
+}
+
 impl FileConsumer {
     fn wrap(backend: ConsumerBackend) -> Self {
         Self {
@@ -2051,12 +2070,7 @@ impl FileConsumer {
         // the cost of cross-restart deduplication.
         consumer.run_epoch = (config.source_metadata
             && !matches!(&config.mode, None | Some(FileConsumerMode::Consume { .. })))
-        .then(|| {
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0)
-        });
+        .then(next_run_epoch);
         Ok(consumer)
     }
 

--- a/src/endpoints/file/tests.rs
+++ b/src/endpoints/file/tests.rs
@@ -617,7 +617,6 @@ async fn resuming_file_modes_get_a_run_epoch_so_reruns_cannot_reuse_a_record_ind
 
     // A second run restarts the record index at 0, so the epoch is what stops it from
     // naming those records the same as the first run's and having them dropped.
-    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
     let mut second = FileConsumer::new(&config).await.unwrap();
     let batch = second.receive_batch(10).await.unwrap();
     let second_run = SourcePosition::from_message(&batch.messages[0]).unwrap();
@@ -625,6 +624,41 @@ async fn resuming_file_modes_get_a_run_epoch_so_reruns_cannot_reuse_a_record_ind
     assert_ne!(first_run.source, second_run.source);
     // A later run reads later records, so its objects must sort after the earlier run's.
     assert!(first_run.source < second_run.source);
+}
+
+#[tokio::test]
+async fn run_epochs_are_distinct_for_consumers_created_in_the_same_millisecond() {
+    use crate::support::source_ranges::SourcePosition;
+
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("orders.jsonl");
+    std::fs::write(&input, "{\"id\":1}\n").unwrap();
+
+    let config = FileConfig {
+        path: input.to_string_lossy().into_owned(),
+        source_metadata: true,
+        mode: Some(FileConsumerMode::GroupSubscribe {
+            group_id: "same-ms".into(),
+            read_from_tail: false,
+        }),
+        ..Default::default()
+    };
+
+    // No sleep between them: the epoch is allocated monotonically, not read off the clock.
+    let mut first = FileConsumer::new(&config).await.unwrap();
+    let mut second = FileConsumer::new(&config).await.unwrap();
+
+    let a = first.receive_batch(10).await.unwrap();
+    let b = second.receive_batch(10).await.unwrap();
+    let first_run = SourcePosition::from_message(&a.messages[0]).unwrap();
+    let second_run = SourcePosition::from_message(&b.messages[0]).unwrap();
+
+    assert!(
+        first_run.source < second_run.source,
+        "epochs must be distinct and increasing: {:?} vs {:?}",
+        first_run.source,
+        second_run.source
+    );
 }
 
 #[tokio::test]

--- a/src/endpoints/file/tests.rs
+++ b/src/endpoints/file/tests.rs
@@ -450,8 +450,8 @@ async fn idempotent_file_sink_replays_only_uncovered_kafka_offsets_after_restart
         names,
         vec![
             ".stage-inflight".to_string(),
-            "part-orders-0-0-1.jsonl".to_string(),
-            "part-orders-0-2-2.jsonl".to_string(),
+            "part-orders-0000000000-00000000000000000000-00000000000000000001.jsonl".to_string(),
+            "part-orders-0000000000-00000000000000000002-00000000000000000002.jsonl".to_string(),
         ]
     );
 }
@@ -489,7 +489,8 @@ async fn idempotent_file_parts_are_compressed_and_named_for_it() {
     drop(publisher);
 
     // One part file, named for the codec, holding one gzip member with both records.
-    let part = output.join("part-orders-0-0-1.jsonl.gz");
+    let part =
+        output.join("part-orders-0000000000-00000000000000000000-00000000000000000001.jsonl.gz");
     let raw = std::fs::read(&part).unwrap();
     let plain =
         crate::support::compression::decompress_all(crate::models::Compression::Gzip, &raw, None)
@@ -512,7 +513,12 @@ async fn idempotent_file_parts_are_compressed_and_named_for_it() {
         .unwrap()
         .map(|entry| entry.unwrap().file_name().into_string().unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(names, vec!["part-orders-0-0-1.jsonl.gz".to_string()]);
+    assert_eq!(
+        names,
+        vec![
+            "part-orders-0000000000-00000000000000000000-00000000000000000001.jsonl.gz".to_string()
+        ]
+    );
 }
 
 #[tokio::test]
@@ -531,6 +537,123 @@ async fn idempotent_file_sink_rejects_records_without_source_metadata() {
         .await
         .is_err());
     assert!(std::fs::read_dir(output).unwrap().next().is_none());
+}
+
+#[tokio::test]
+async fn file_source_metadata_numbers_records_and_feeds_an_idempotent_sink() {
+    use crate::traits::MessageConsumer;
+
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("orders.jsonl");
+    std::fs::write(&input, "{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n").unwrap();
+
+    let source = FileConfig {
+        path: input.to_string_lossy().into_owned(),
+        source_metadata: true,
+        ..Default::default()
+    };
+    let mut consumer = FileConsumer::new(&source).await.unwrap();
+    let batch = consumer.receive_batch(10).await.unwrap();
+    assert_eq!(batch.messages.len(), 3);
+
+    // Records are numbered by index, not byte offset, so they stay consecutive.
+    let records = batch
+        .messages
+        .iter()
+        .map(|m| m.metadata.get("mqb.src.file_record").unwrap().as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(records, vec!["0", "1", "2"]);
+
+    // The whole batch lands as one part file covering records 0-2.
+    let output = dir.path().join("parts");
+    let sink = FileConfig {
+        path: output.to_string_lossy().into_owned(),
+        idempotency: true,
+        ..Default::default()
+    };
+    let publisher = FilePublisher::new(&sink).await.unwrap();
+    publisher.send_batch(batch.messages).await.unwrap();
+
+    let names = std::fs::read_dir(&output)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().into_string().unwrap())
+        .filter(|name| !name.starts_with(".stage"))
+        .collect::<Vec<_>>();
+    assert_eq!(names.len(), 1, "one object per contiguous run: {names:?}");
+    assert!(
+        names[0].ends_with("-00000000000000000000-00000000000000000002.jsonl"),
+        "unexpected part name {}",
+        names[0]
+    );
+}
+
+#[tokio::test]
+async fn resuming_file_modes_get_a_run_epoch_so_reruns_cannot_reuse_a_record_index() {
+    use crate::support::source_ranges::SourcePosition;
+    use crate::traits::MessageConsumer;
+
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("orders.jsonl");
+    std::fs::write(&input, "{\"id\":1}\n{\"id\":2}\n").unwrap();
+
+    let config = FileConfig {
+        path: input.to_string_lossy().into_owned(),
+        source_metadata: true,
+        mode: Some(FileConsumerMode::GroupSubscribe {
+            group_id: "g1".into(),
+            read_from_tail: false,
+        }),
+        ..Default::default()
+    };
+
+    // Allowed, not rejected: the setup is only weaker, not wrong.
+    let mut first = FileConsumer::new(&config).await.unwrap();
+    let batch = first.receive_batch(10).await.unwrap();
+    assert!(!batch.messages.is_empty());
+    let first_run = SourcePosition::from_message(&batch.messages[0]).unwrap();
+    assert!(batch.messages[0]
+        .metadata
+        .contains_key("mqb.src.file_epoch"));
+
+    // A second run restarts the record index at 0, so the epoch is what stops it from
+    // naming those records the same as the first run's and having them dropped.
+    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    let mut second = FileConsumer::new(&config).await.unwrap();
+    let batch = second.receive_batch(10).await.unwrap();
+    let second_run = SourcePosition::from_message(&batch.messages[0]).unwrap();
+
+    assert_ne!(first_run.source, second_run.source);
+    // A later run reads later records, so its objects must sort after the earlier run's.
+    assert!(first_run.source < second_run.source);
+}
+
+#[tokio::test]
+async fn consume_mode_repeats_its_record_identity_across_runs() {
+    use crate::support::source_ranges::SourcePosition;
+    use crate::traits::MessageConsumer;
+
+    let dir = tempdir().unwrap();
+    let input = dir.path().join("orders.jsonl");
+    std::fs::write(&input, "{\"id\":1}\n{\"id\":2}\n").unwrap();
+
+    let config = FileConfig {
+        path: input.to_string_lossy().into_owned(),
+        source_metadata: true,
+        ..Default::default()
+    };
+
+    let mut first = FileConsumer::new(&config).await.unwrap();
+    let a = first.receive_batch(10).await.unwrap();
+    let mut second = FileConsumer::new(&config).await.unwrap();
+    let b = second.receive_batch(10).await.unwrap();
+
+    // No epoch: re-reading the same file must produce the same names, which is exactly
+    // how the idempotent sink recognises the rewrite and skips it.
+    assert!(!a.messages[0].metadata.contains_key("mqb.src.file_epoch"));
+    assert_eq!(
+        SourcePosition::from_message(&a.messages[0]).unwrap(),
+        SourcePosition::from_message(&b.messages[0]).unwrap()
+    );
 }
 
 #[tokio::test]
@@ -578,8 +701,8 @@ async fn idempotent_file_sink_replays_postgres_cdc_changes_in_one_commit() {
     assert_eq!(
         names,
         vec![
-            "part-postgres_cdc-bridge_slot-9876543210-0-0-1.jsonl".to_string(),
-            "part-postgres_cdc-bridge_slot-9876543210-0-2-2.jsonl".to_string(),
+            "part-postgres_cdc-bridge_slot-00000000009876543210-0000000000-00000000000000000000-00000000000000000001.jsonl".to_string(),
+            "part-postgres_cdc-bridge_slot-00000000009876543210-0000000000-00000000000000000002-00000000000000000002.jsonl".to_string(),
         ]
     );
 }

--- a/src/endpoints/http/mod.rs
+++ b/src/endpoints/http/mod.rs
@@ -643,8 +643,9 @@ fn http_version_str(version: hyper::Version) -> &'static str {
     }
 }
 
-/// Credential-bearing request headers that must not be copied into message
-/// metadata, where they could be logged, persisted, or echoed back on the reply.
+/// Credential-bearing request headers. They reach metadata under
+/// [`SENSITIVE_HEADER_METADATA_PREFIX`] rather than under their own name, so they stop at the
+/// route handler instead of being forwarded.
 fn is_sensitive_request_header(name: &str) -> bool {
     const SENSITIVE: [&str; 6] = [
         "authorization",
@@ -656,6 +657,15 @@ fn is_sensitive_request_header(name: &str) -> bool {
     ];
     SENSITIVE.iter().any(|h| name.eq_ignore_ascii_case(h))
 }
+
+/// Metadata namespace for credential-bearing request headers, e.g. `mqb.src.http_authorization`,
+/// keeping the header name verbatim after the prefix.
+///
+/// Sits under [`SOURCE_METADATA_PREFIX`](crate::canonical_message::SOURCE_METADATA_PREFIX), which
+/// is what makes carrying the value safe: every publisher drops this prefix when serializing
+/// metadata, so the route handler sees the header the client actually sent while no sink, and no
+/// response header, ever does. See the `sensitive_header_*` tests.
+pub const SENSITIVE_HEADER_METADATA_PREFIX: &str = "mqb.src.http_";
 
 fn request_metadata_matches(request: &RequestMetadataView<'_>, key: &str, value: &str) -> bool {
     match key {
@@ -1586,14 +1596,23 @@ async fn handle_request_internal(
                 content_encoding = Some(v_str.to_string());
             }
             let k_str = key.as_str();
+            // `mqb.src.*` is reserved for framework provenance, so a request header may never
+            // supply one: without this a client could forge its own `mqb.src.http_authorization`.
             if k_str == HTTP_METHOD
                 || k_str == HTTP_PATH
                 || k_str == HTTP_QUERY
                 || k_str == HTTP_VERSION
                 || k_str.eq_ignore_ascii_case("tls_cipher_suite")
                 || k_str.eq_ignore_ascii_case("tls_protocol_version")
-                || is_sensitive_request_header(k_str)
+                || crate::canonical_message::is_source_metadata_key(k_str)
             {
+                continue;
+            }
+            if is_sensitive_request_header(k_str) {
+                metadata.insert(
+                    format!("{SENSITIVE_HEADER_METADATA_PREFIX}{k_str}"),
+                    v_str.to_string(),
+                );
                 continue;
             }
             metadata.insert(k_str.to_string(), v_str.to_string());

--- a/src/endpoints/http/tests.rs
+++ b/src/endpoints/http/tests.rs
@@ -1684,3 +1684,354 @@ async fn consumer_receive_ack(consumer: &mut HttpConsumer) -> CanonicalMessage {
         .unwrap();
     message
 }
+
+// --- Sensitive request headers -------------------------------------------------------------
+// Credential headers reach the handler verbatim, under the reserved `mqb.src.` namespace that
+// every publisher strips on the way out. See `SENSITIVE_HEADER_METADATA_PREFIX`.
+
+fn basic_credentials(user_pass: &str) -> String {
+    format!("Basic {}", general_purpose::STANDARD.encode(user_pass))
+}
+
+fn test_http_client(
+) -> hyper_util::client::legacy::Client<HttpConnector, http_body_util::Full<Bytes>> {
+    let mut connector = HttpConnector::new();
+    connector.set_nodelay(true);
+    hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build(connector)
+}
+
+/// Sends one request carrying `headers` to a bare consumer and returns the metadata the
+/// handler ends up seeing.
+async fn handler_metadata_for_request_headers(headers: &[(&str, &str)]) -> HashMap<String, String> {
+    init_crypto();
+    let port = get_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let config = HttpConfig {
+        url: addr.clone(),
+        ..Default::default()
+    };
+    let mut consumer = HttpConsumer::new(&config).await.unwrap();
+
+    let receive_task = tokio::spawn(async move {
+        let received = consumer
+            .receive()
+            .await
+            .expect("request never reached the handler");
+        let _ = (received.commit)(crate::traits::MessageDisposition::Ack).await;
+        received.message
+    });
+
+    assert!(wait_for_server_ready(&addr, Duration::from_secs(5)).await);
+
+    let mut request = Request::builder()
+        .method(hyper::Method::POST)
+        .uri(format!("http://{addr}/"));
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+    let response = test_http_client()
+        .request(
+            request
+                .body(http_body_util::Full::<Bytes>::new(Bytes::from_static(
+                    b"body",
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    receive_task.await.unwrap().metadata
+}
+
+#[test]
+fn test_sensitive_header_prefix_is_reserved_source_metadata() {
+    // The design rests on this: publishers drop `mqb.src.*` when serializing metadata, so the
+    // credential reaches the handler but never a sink or a response header.
+    assert!(SENSITIVE_HEADER_METADATA_PREFIX
+        .starts_with(crate::canonical_message::SOURCE_METADATA_PREFIX));
+    assert!(crate::canonical_message::is_source_metadata_key(&format!(
+        "{SENSITIVE_HEADER_METADATA_PREFIX}authorization"
+    )));
+}
+
+#[tokio::test]
+async fn test_sensitive_request_headers_reach_handler_verbatim() {
+    let metadata = handler_metadata_for_request_headers(&[
+        ("authorization", "Basic dXNlcjpwYXNzd29yZA=="),
+        ("cookie", "session=abc123"),
+        ("x-api-key", "super-secret-key"),
+        ("x-trace-id", "trace-42"),
+    ])
+    .await;
+
+    // The handler gets what the client actually sent, so "is the client authenticating, and
+    // with what" is answerable while debugging.
+    assert_eq!(
+        metadata
+            .get("mqb.src.http_authorization")
+            .map(String::as_str),
+        Some("Basic dXNlcjpwYXNzd29yZA==")
+    );
+    assert_eq!(
+        metadata.get("mqb.src.http_cookie").map(String::as_str),
+        Some("session=abc123")
+    );
+    assert_eq!(
+        metadata.get("mqb.src.http_x-api-key").map(String::as_str),
+        Some("super-secret-key")
+    );
+
+    // The plain names stay absent, so nothing reading `metadata["authorization"]` today
+    // suddenly starts seeing a credential, and no publisher can forward one.
+    assert!(!metadata.contains_key("authorization"));
+    assert!(!metadata.contains_key("cookie"));
+    assert!(!metadata.contains_key("x-api-key"));
+
+    // Ordinary headers are untouched.
+    assert_eq!(
+        metadata.get("x-trace-id").map(String::as_str),
+        Some("trace-42")
+    );
+
+    // Every key holding a credential is reserved, hence dropped by each publisher.
+    for (key, value) in &metadata {
+        if value.contains("dXNlcjpwYXNzd29yZA==")
+            || value.contains("abc123")
+            || value.contains("super-secret-key")
+        {
+            assert!(
+                crate::canonical_message::is_source_metadata_key(key),
+                "credential sits in forwardable metadata key {key:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_spoofed_source_metadata_request_headers_are_dropped() {
+    // A client must not be able to forge the reserved namespace and have the handler show
+    // its value as if it were the real request header.
+    let metadata = handler_metadata_for_request_headers(&[
+        ("mqb.src.http_authorization", "Basic injected"),
+        ("mqb.src.kafka_offset", "999"),
+        ("x-trace-id", "trace-42"),
+    ])
+    .await;
+
+    assert!(
+        !metadata.keys().any(|key| key.starts_with("mqb.src.")),
+        "spoofed source metadata survived: {metadata:?}"
+    );
+    assert_eq!(
+        metadata.get("x-trace-id").map(String::as_str),
+        Some("trace-42")
+    );
+}
+
+#[tokio::test]
+async fn test_sensitive_header_metadata_is_not_echoed_on_the_reply() {
+    init_crypto();
+    let port = get_free_port();
+    let addr = format!("127.0.0.1:{port}");
+
+    // The routed path applies no request-echo suppression (see
+    // `test_http_route_inline_response_can_be_disabled`), so it is where a reserved-prefix key
+    // would surface as a response header if it were forwardable.
+    let input = Endpoint::new(EndpointType::Http(HttpConfig {
+        url: addr.clone(),
+        path: Some("/echo".to_string()),
+        inline_response_fast_path: Some(false),
+        ..Default::default()
+    }));
+    let output = Endpoint::new(EndpointType::Response(
+        crate::models::ResponseConfig::default(),
+    ));
+    let handle = crate::Route::new(input, output)
+        .run("test_http_sensitive_header_reply")
+        .await
+        .unwrap();
+
+    assert!(wait_for_server_ready(&addr, Duration::from_secs(5)).await);
+
+    let response = test_http_client()
+        .request(
+            Request::builder()
+                .method(hyper::Method::POST)
+                .uri(format!("http://{addr}/echo"))
+                .header("authorization", "Basic dXNlcjpwYXNzd29yZA==")
+                .header("cookie", "session=abc123")
+                .body(http_body_util::Full::<Bytes>::new(Bytes::from_static(
+                    b"echo me",
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let headers: String = response
+        .headers()
+        .iter()
+        .map(|(name, value)| format!("{name}: {}\n", value.to_str().unwrap_or("")))
+        .collect();
+    assert!(
+        !headers.contains("mqb.src."),
+        "reserved metadata leaked as a response header: {headers}"
+    );
+    assert!(
+        !headers.contains("dXNlcjpwYXNzd29yZA==") && !headers.contains("abc123"),
+        "credential echoed on the reply: {headers}"
+    );
+    assert!(response.headers().get("authorization").is_none());
+    assert!(response.headers().get("cookie").is_none());
+
+    handle.stop().await;
+    let _ = handle.join().await;
+}
+
+#[tokio::test]
+async fn test_basic_auth_enforcement_is_unaffected_by_header_capture() {
+    init_crypto();
+    let port = get_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let config = HttpConfig {
+        url: addr.clone(),
+        basic_auth: Some(("user".to_string(), "password".to_string())),
+        ..Default::default()
+    };
+    let mut consumer = HttpConsumer::new(&config).await.unwrap();
+
+    let receive_task = tokio::spawn(async move {
+        let received = consumer
+            .receive()
+            .await
+            .expect("authorized request never reached the handler");
+        let _ = (received.commit)(crate::traits::MessageDisposition::Ack).await;
+        received.message
+    });
+
+    assert!(wait_for_server_ready(&addr, Duration::from_secs(5)).await);
+    let client = test_http_client();
+
+    let build = |auth: Option<String>| {
+        let mut request = Request::builder()
+            .method(hyper::Method::POST)
+            .uri(format!("http://{addr}/"));
+        if let Some(auth) = auth {
+            request = request.header("authorization", auth);
+        }
+        request
+            .body(http_body_util::Full::<Bytes>::new(Bytes::from_static(
+                b"body",
+            )))
+            .unwrap()
+    };
+
+    // Enforcement reads the request headers directly, before metadata is built.
+    let missing = client.request(build(None)).await.unwrap();
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+    let wrong = client
+        .request(build(Some(basic_credentials("user:wrong"))))
+        .await
+        .unwrap();
+    assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+
+    let accepted = client
+        .request(build(Some(basic_credentials("user:password"))))
+        .await
+        .unwrap();
+    assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+
+    let metadata = receive_task.await.unwrap().metadata;
+    assert_eq!(
+        metadata
+            .get("mqb.src.http_authorization")
+            .map(String::as_str),
+        Some(basic_credentials("user:password").as_str())
+    );
+}
+
+#[tokio::test]
+async fn test_sensitive_header_metadata_is_not_written_to_a_sink() {
+    // End-to-end proof of the forwarding half: the `json` file sink serialises the whole
+    // metadata map, so if the reserved prefix were forwardable the credential would land on
+    // disk verbatim. Covers the same `strip_source_metadata` contract every other sink uses.
+    init_crypto();
+    let port = get_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let dir = tempfile::tempdir().unwrap();
+    let out_path = dir.path().join("sink.jsonl");
+
+    let input = Endpoint::new(EndpointType::Http(HttpConfig {
+        url: addr.clone(),
+        path: Some("/ingest".to_string()),
+        fire_and_forget: true,
+        ..Default::default()
+    }));
+    let output = Endpoint::new(EndpointType::File(crate::models::FileConfig {
+        path: out_path.to_string_lossy().to_string(),
+        format: crate::models::FileFormat::Json,
+        ..Default::default()
+    }));
+    let handle = crate::Route::new(input, output)
+        .run("test_http_sensitive_header_sink")
+        .await
+        .unwrap();
+
+    assert!(wait_for_server_ready(&addr, Duration::from_secs(5)).await);
+
+    let response = test_http_client()
+        .request(
+            Request::builder()
+                .method(hyper::Method::POST)
+                .uri(format!("http://{addr}/ingest"))
+                .header("authorization", "Basic dXNlcjpwYXNzd29yZA==")
+                .header("cookie", "session=abc123")
+                .header("x-api-key", "super-secret-key")
+                .header("x-trace-id", "trace-42")
+                .body(http_body_util::Full::<Bytes>::new(Bytes::from_static(
+                    b"{\"v\":1}",
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let mut written = String::new();
+    for _ in 0..100 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        written = std::fs::read_to_string(&out_path).unwrap_or_default();
+        if written.contains("trace-42") {
+            break;
+        }
+    }
+    assert!(
+        written.contains("trace-42"),
+        "route never reached the file sink: {written:?}"
+    );
+
+    // The ordinary header survives the hop; every credential-bearing one is gone.
+    assert!(
+        !written.contains("mqb.src."),
+        "reserved metadata written to sink: {written}"
+    );
+    for secret in [
+        "dXNlcjpwYXNzd29yZA==",
+        "abc123",
+        "super-secret-key",
+        "authorization",
+        "cookie",
+        "x-api-key",
+    ] {
+        assert!(
+            !written.contains(secret),
+            "{secret:?} leaked to the file sink: {written}"
+        );
+    }
+
+    handle.stop().await;
+    let _ = handle.join().await;
+}

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -674,7 +674,7 @@ pub async fn create_consumer_from_route_with_source_metadata(
     check_consumer(route_name, &resolved_endpoint, None)?;
     if source_metadata_required && !supports_source_metadata(&resolved_endpoint.endpoint_type) {
         return Err(anyhow!(
-            "[route:{route_name}] idempotent file/object_store output requires a Kafka or Postgres CDC input"
+            "[route:{route_name}] idempotent file/object_store output requires an input that carries a replay position: kafka, postgres_cdc, sqlx, mongodb (change stream) or file"
         ));
     }
     let source_metadata =
@@ -692,6 +692,24 @@ fn supports_source_metadata(endpoint_type: &EndpointType) -> bool {
         endpoint_type,
         EndpointType::Kafka(_) | EndpointType::PostgresCdc(_)
     ) || matches!(endpoint_type, EndpointType::Sqlx(config) if config.publication.is_some())
+        // A polling cursor is itself a replay position, provided it is a unique integer;
+        // the reader rejects text and repeated values rather than naming records wrongly.
+        || matches!(endpoint_type, EndpointType::Sqlx(config) if config.cursor_column.is_some())
+        // The change-stream reader positions changes by cluster time and its initial
+        // snapshot by `_id` scan index. The `consumer`/`snapshot` readers have neither.
+        || matches!(
+            endpoint_type,
+            EndpointType::MongoDb(config) if matches!(
+                config.consume,
+                Some(crate::models::MongoConsume::CaptureNew)
+                    | Some(crate::models::MongoConsume::CaptureAll)
+                    | None
+            )
+        )
+        // Every file mode positions records by index. Only `consume` reproduces that index
+        // across runs; the others add a run epoch, which keeps them ordered and distinct
+        // but not deduplicated. That is a weaker guarantee, not an invalid setup.
+        || matches!(endpoint_type, EndpointType::File(_))
 }
 
 fn source_metadata_requested(endpoint_type: &EndpointType) -> bool {
@@ -700,17 +718,49 @@ fn source_metadata_requested(endpoint_type: &EndpointType) -> bool {
         EndpointType::Nats(config) => config.source_metadata,
         EndpointType::Amqp(config) => config.source_metadata,
         EndpointType::PostgresCdc(config) => config.source_metadata,
+        EndpointType::MongoDb(config) => config.source_metadata,
+        EndpointType::File(config) => config.source_metadata,
+        EndpointType::Sqlx(config) => config.source_metadata,
         _ => false,
     }
 }
 
 /// Whether a route's resolved output contains an idempotent file or object-store sink.
 pub fn output_requires_source_metadata(route_name: &str, endpoint: &Endpoint) -> Result<bool> {
+    output_has_sink(route_name, endpoint, &|endpoint_type| match endpoint_type {
+        EndpointType::File(config) => config.idempotency,
+        EndpointType::ObjectStore(config) => config.idempotency,
+        _ => false,
+    })
+}
+
+/// Whether a route's resolved output contains an object-store sink that names objects in
+/// write order. Key order is the only order a bucket has, and above `concurrency: 1` write
+/// order is worker arrival order rather than source order.
+pub fn output_has_write_ordered_object_store(
+    route_name: &str,
+    endpoint: &Endpoint,
+) -> Result<bool> {
+    output_has_sink(
+        route_name,
+        endpoint,
+        &|endpoint_type| matches!(endpoint_type, EndpointType::ObjectStore(config) if !config.idempotency),
+    )
+}
+
+/// Walk a resolved output tree — through `fanout`, `switch`, `reader`, `request` and `ref` —
+/// and report whether any leaf sink matches.
+fn output_has_sink(
+    route_name: &str,
+    endpoint: &Endpoint,
+    matches_leaf: &dyn Fn(&EndpointType) -> bool,
+) -> Result<bool> {
     fn visit(
         route_name: &str,
         endpoint: &Endpoint,
         depth: usize,
         visited_refs: &mut std::collections::HashSet<String>,
+        matches_leaf: &dyn Fn(&EndpointType) -> bool,
     ) -> Result<bool> {
         const MAX_DEPTH: usize = 16;
         if depth > MAX_DEPTH {
@@ -719,18 +769,16 @@ pub fn output_requires_source_metadata(route_name: &str, endpoint: &Endpoint) ->
             ));
         }
         match &endpoint.endpoint_type {
-            EndpointType::File(config) => Ok(config.idempotency),
-            EndpointType::ObjectStore(config) => Ok(config.idempotency),
             EndpointType::Fanout(outputs) => outputs
                 .iter()
-                .map(|output| visit(route_name, output, depth + 1, visited_refs))
+                .map(|output| visit(route_name, output, depth + 1, visited_refs, matches_leaf))
                 .collect::<Result<Vec<_>>>()
                 .map(|requirements| requirements.into_iter().any(|required| required)),
             EndpointType::Switch(config) => {
                 let cases_required = config
                     .cases
                     .values()
-                    .map(|output| visit(route_name, output, depth + 1, visited_refs))
+                    .map(|output| visit(route_name, output, depth + 1, visited_refs, matches_leaf))
                     .collect::<Result<Vec<_>>>()?
                     .into_iter()
                     .any(|required| required);
@@ -738,15 +786,26 @@ pub fn output_requires_source_metadata(route_name: &str, endpoint: &Endpoint) ->
                     Ok(true)
                 } else {
                     config.default.as_deref().map_or(Ok(false), |output| {
-                        visit(route_name, output, depth + 1, visited_refs)
+                        visit(route_name, output, depth + 1, visited_refs, matches_leaf)
                     })
                 }
             }
-            EndpointType::Reader(output) => visit(route_name, output, depth + 1, visited_refs),
-            EndpointType::Request(config) => {
-                Ok(visit(route_name, &config.to, depth + 1, visited_refs)?
-                    || visit(route_name, &config.forward_to, depth + 1, visited_refs)?)
+            EndpointType::Reader(output) => {
+                visit(route_name, output, depth + 1, visited_refs, matches_leaf)
             }
+            EndpointType::Request(config) => Ok(visit(
+                route_name,
+                &config.to,
+                depth + 1,
+                visited_refs,
+                matches_leaf,
+            )? || visit(
+                route_name,
+                &config.forward_to,
+                depth + 1,
+                visited_refs,
+                matches_leaf,
+            )?),
             EndpointType::Ref(name) => {
                 if !visited_refs.insert(name.clone()) {
                     return Err(anyhow!(
@@ -756,11 +815,17 @@ pub fn output_requires_source_metadata(route_name: &str, endpoint: &Endpoint) ->
                 let referenced = crate::route::get_endpoint(name).ok_or_else(|| {
                     anyhow!("[route:{route_name}] referenced output endpoint '{name}' not found")
                 })?;
-                let required = visit(route_name, &referenced, depth + 1, visited_refs);
+                let required = visit(
+                    route_name,
+                    &referenced,
+                    depth + 1,
+                    visited_refs,
+                    matches_leaf,
+                );
                 visited_refs.remove(name);
                 required
             }
-            _ => Ok(false),
+            leaf => Ok(matches_leaf(leaf)),
         }
     }
 
@@ -769,6 +834,7 @@ pub fn output_requires_source_metadata(route_name: &str, endpoint: &Endpoint) ->
         endpoint,
         0,
         &mut std::collections::HashSet::new(),
+        matches_leaf,
     )
 }
 
@@ -1063,7 +1129,9 @@ async fn create_base_consumer(
                 }
             } else if cfg.cursor_column.is_some() {
                 // Non-destructive, resumable cursor read of an arbitrary table.
-                Ok(boxed(sqlx::SqlxCursorReader::new(cfg).await?))
+                Ok(boxed(
+                    sqlx::SqlxCursorReader::new_with_source_metadata(cfg, _source_metadata).await?,
+                ))
             } else {
                 Ok(boxed(sqlx::SqlxConsumer::new(cfg).await?))
             }
@@ -1955,6 +2023,50 @@ mod tests {
         assert!(output_requires_source_metadata("test", &switch).unwrap());
     }
 
+    /// Only a write-ordered object store is worth warning about: an idempotent one names
+    /// objects by source position, so concurrency cannot reorder them.
+    #[cfg(feature = "object-store")]
+    #[test]
+    fn write_ordered_object_store_is_detected_through_the_output_tree() {
+        fn bucket(idempotency: bool) -> Endpoint {
+            Endpoint::new(EndpointType::ObjectStore(
+                crate::models::ObjectStoreConfig {
+                    url: "s3://bucket/data".to_string(),
+                    idempotency,
+                    ..Default::default()
+                },
+            ))
+        }
+
+        let fanout = Endpoint::new(EndpointType::Fanout(vec![
+            Endpoint::new_memory("ordinary", 1),
+            bucket(false),
+        ]));
+        assert!(output_has_write_ordered_object_store("test", &fanout).unwrap());
+
+        let idempotent = Endpoint::new(EndpointType::Fanout(vec![bucket(true)]));
+        assert!(!output_has_write_ordered_object_store("test", &idempotent).unwrap());
+    }
+
+    /// A polling cursor is a replay position, so an idempotent sink accepts it — where a
+    /// plain `sqlx` queue read (no `cursor_column`) still has nothing to sequence by.
+    #[cfg(feature = "sqlx")]
+    #[test]
+    fn sqlx_is_a_replay_source_only_in_cursor_or_cdc_mode() {
+        let cursor = EndpointType::Sqlx(crate::models::SqlxConfig {
+            table: "orders".to_string(),
+            cursor_column: Some("id".to_string()),
+            ..Default::default()
+        });
+        assert!(supports_source_metadata(&cursor));
+
+        let queue = EndpointType::Sqlx(crate::models::SqlxConfig {
+            table: "orders".to_string(),
+            ..Default::default()
+        });
+        assert!(!supports_source_metadata(&queue));
+    }
+
     #[tokio::test]
     async fn idempotent_output_rejects_a_source_without_replay_position() {
         let result = create_consumer_from_route_with_source_metadata(
@@ -1969,7 +2081,7 @@ mod tests {
         };
         assert!(error
             .to_string()
-            .contains("requires a Kafka or Postgres CDC input"));
+            .contains("requires an input that carries a replay position"));
     }
 
     /// NATS emits `mqb.src.*` provenance but no replayable offset. The guard must reject it up
@@ -1992,7 +2104,7 @@ mod tests {
         };
         assert!(error
             .to_string()
-            .contains("requires a Kafka or Postgres CDC input"));
+            .contains("requires an input that carries a replay position"));
     }
 
     #[tokio::test]

--- a/src/endpoints/mongodb/readers.rs
+++ b/src/endpoints/mongodb/readers.rs
@@ -340,7 +340,29 @@ pub struct MongoDbChangeStreamReader {
     source_metadata: bool,
     /// `<database>.<collection>`, precomputed for the `mqb.src.mongodb_namespace` key.
     namespace: String,
+    /// Contiguous positions an idempotent sink needs: changes numbered within their cluster
+    /// time, snapshot documents within the scan.
+    ordinals: Arc<Mutex<OrdinalCounter>>,
     exit_on_empty: bool,
+}
+
+/// Hands out consecutive ordinals within a group, restarting at 0 when the group changes.
+#[derive(Default)]
+pub(super) struct OrdinalCounter {
+    group: Option<u64>,
+    next: u64,
+}
+
+impl OrdinalCounter {
+    fn next_in(&mut self, group: u64) -> u64 {
+        if self.group != Some(group) {
+            self.group = Some(group);
+            self.next = 0;
+        }
+        let ordinal = self.next;
+        self.next += 1;
+        ordinal
+    }
 }
 
 impl MongoDbChangeStreamReader {
@@ -470,6 +492,7 @@ impl MongoDbChangeStreamReader {
             )),
             source_metadata,
             namespace: format!("{}.{}", config.database, collection_name),
+            ordinals: Arc::new(Mutex::new(OrdinalCounter::default())),
             exit_on_empty: false,
         })
     }
@@ -520,7 +543,12 @@ impl MongoDbChangeStreamReader {
                         msg.metadata.insert("mongodb.document_id".to_string(), enc);
                     }
                     if self.source_metadata {
-                        add_snapshot_source_metadata(&mut msg, &self.namespace, &id);
+                        add_snapshot_source_metadata(
+                            &mut msg,
+                            &self.namespace,
+                            &id,
+                            &self.ordinals,
+                        );
                     }
                     messages.push(msg);
                     ids.push(id.clone());
@@ -578,6 +606,7 @@ impl MongoDbChangeStreamReader {
         event: &ChangeStreamEvent<Document>,
         source_metadata: bool,
         namespace: &str,
+        ordinals: &Mutex<OrdinalCounter>,
     ) -> Option<CanonicalMessage> {
         let (op, payload) = match event.operation_type {
             OperationType::Insert | OperationType::Update | OperationType::Replace => {
@@ -605,7 +634,7 @@ impl MongoDbChangeStreamReader {
             }
         }
         if source_metadata {
-            add_source_metadata(&mut msg, event, namespace);
+            add_source_metadata(&mut msg, event, namespace, ordinals);
         }
         Some(msg)
     }
@@ -691,23 +720,40 @@ fn add_source_metadata(
     message: &mut CanonicalMessage,
     event: &ChangeStreamEvent<Document>,
     namespace: &str,
+    ordinals: &Mutex<OrdinalCounter>,
 ) {
-    message.metadata.insert(
-        "mqb.src.mongodb_namespace".to_string(),
-        namespace.to_string(),
-    );
     if let Ok(token) = encode_resume_token(&event.id) {
         message
             .metadata
             .insert("mqb.src.mongodb_resume_token".to_string(), token);
     }
-    if let Some(ts) = event.cluster_time {
-        let packed = (u64::from(ts.time) << 32) | u64::from(ts.increment);
-        message.metadata.insert(
-            "mqb.src.mongodb_cluster_time".to_string(),
-            packed.to_string(),
+    let Some(ts) = event.cluster_time else {
+        // Without a cluster time the event has no orderable position. The namespace is left
+        // off as well: on its own it would select the sink's CDC path, which then fails the
+        // whole batch on the missing cluster time.
+        warn!(
+            "MongoDB change event has no clusterTime; omitting mqb.src.mongodb_* source position"
         );
-    }
+        return;
+    };
+    message.metadata.insert(
+        "mqb.src.mongodb_namespace".to_string(),
+        namespace.to_string(),
+    );
+    let packed = (u64::from(ts.time) << 32) | u64::from(ts.increment);
+    message.metadata.insert(
+        "mqb.src.mongodb_cluster_time".to_string(),
+        packed.to_string(),
+    );
+    // Every change in a transaction shares a cluster time; the ordinal separates them
+    // so an idempotent sink can name them as one contiguous range.
+    let ordinal = ordinals
+        .lock()
+        .expect("ordinal counter poisoned")
+        .next_in(packed);
+    message
+        .metadata
+        .insert("mqb.src.mongodb_ordinal".to_string(), ordinal.to_string());
 }
 
 /// Tags a snapshot document with the stable identity used when it is redelivered.
@@ -715,6 +761,7 @@ pub(super) fn add_snapshot_source_metadata(
     message: &mut CanonicalMessage,
     namespace: &str,
     id: &Bson,
+    ordinals: &Mutex<OrdinalCounter>,
 ) {
     message.metadata.insert(
         "mqb.src.mongodb_namespace".to_string(),
@@ -725,6 +772,17 @@ pub(super) fn add_snapshot_source_metadata(
             .metadata
             .insert("mqb.src.mongodb_document_id".to_string(), document_id);
     }
+    // The scan is ordered by ascending `_id`, so this index is deterministic: a restart
+    // re-scans from the start and reproduces the same names, which an idempotent sink skips.
+    // Group 0 — the whole snapshot is one sequence.
+    let index = ordinals
+        .lock()
+        .expect("ordinal counter poisoned")
+        .next_in(0);
+    message.metadata.insert(
+        "mqb.src.mongodb_snapshot_index".to_string(),
+        index.to_string(),
+    );
 }
 
 /// The change-event operation name stored in message metadata.
@@ -795,9 +853,12 @@ impl MessageConsumer for MongoDbChangeStreamReader {
             match poll {
                 Ok(Ok(Some(event))) => {
                     let token = event.id.clone();
-                    if let Some(msg) =
-                        Self::event_to_message(&event, self.source_metadata, &self.namespace)
-                    {
+                    if let Some(msg) = Self::event_to_message(
+                        &event,
+                        self.source_metadata,
+                        &self.namespace,
+                        &self.ordinals,
+                    ) {
                         messages.push(msg);
                         tokens.push(token);
                     }
@@ -832,9 +893,12 @@ impl MessageConsumer for MongoDbChangeStreamReader {
             match tokio::time::timeout(Duration::from_millis(10), stream.next_if_any()).await {
                 Ok(Ok(Some(event))) => {
                     let token = event.id.clone();
-                    if let Some(msg) =
-                        Self::event_to_message(&event, self.source_metadata, &self.namespace)
-                    {
+                    if let Some(msg) = Self::event_to_message(
+                        &event,
+                        self.source_metadata,
+                        &self.namespace,
+                        &self.ordinals,
+                    ) {
                         messages.push(msg);
                         tokens.push(token);
                     }

--- a/src/endpoints/mongodb/readers.rs
+++ b/src/endpoints/mongodb/readers.rs
@@ -340,9 +340,11 @@ pub struct MongoDbChangeStreamReader {
     source_metadata: bool,
     /// `<database>.<collection>`, precomputed for the `mqb.src.mongodb_namespace` key.
     namespace: String,
-    /// Contiguous positions an idempotent sink needs: changes numbered within their cluster
-    /// time, snapshot documents within the scan.
-    ordinals: Arc<Mutex<OrdinalCounter>>,
+    /// Contiguous positions an idempotent sink needs. Kept apart so the two phases cannot
+    /// share a sequence: snapshot documents are numbered within the scan, changes within
+    /// their cluster time.
+    snapshot_ordinals: Arc<Mutex<OrdinalCounter>>,
+    cdc_ordinals: Arc<Mutex<OrdinalCounter>>,
     exit_on_empty: bool,
 }
 
@@ -492,7 +494,8 @@ impl MongoDbChangeStreamReader {
             )),
             source_metadata,
             namespace: format!("{}.{}", config.database, collection_name),
-            ordinals: Arc::new(Mutex::new(OrdinalCounter::default())),
+            snapshot_ordinals: Arc::new(Mutex::new(OrdinalCounter::default())),
+            cdc_ordinals: Arc::new(Mutex::new(OrdinalCounter::default())),
             exit_on_empty: false,
         })
     }
@@ -547,7 +550,7 @@ impl MongoDbChangeStreamReader {
                             &mut msg,
                             &self.namespace,
                             &id,
-                            &self.ordinals,
+                            &self.snapshot_ordinals,
                         );
                     }
                     messages.push(msg);
@@ -857,7 +860,7 @@ impl MessageConsumer for MongoDbChangeStreamReader {
                         &event,
                         self.source_metadata,
                         &self.namespace,
-                        &self.ordinals,
+                        &self.cdc_ordinals,
                     ) {
                         messages.push(msg);
                         tokens.push(token);
@@ -897,7 +900,7 @@ impl MessageConsumer for MongoDbChangeStreamReader {
                         &event,
                         self.source_metadata,
                         &self.namespace,
-                        &self.ordinals,
+                        &self.cdc_ordinals,
                     ) {
                         messages.push(msg);
                         tokens.push(token);

--- a/src/endpoints/mongodb/tests.rs
+++ b/src/endpoints/mongodb/tests.rs
@@ -21,17 +21,26 @@ fn change_event_source_metadata_is_opt_in_and_orders_by_cluster_time() {
     })
     .expect("change event deserializes");
 
-    let off =
-        super::readers::MongoDbChangeStreamReader::event_to_message(&event, false, "shop.orders")
-            .expect("event carries a payload");
+    let ordinals = std::sync::Mutex::new(super::readers::OrdinalCounter::default());
+    let off = super::readers::MongoDbChangeStreamReader::event_to_message(
+        &event,
+        false,
+        "shop.orders",
+        &ordinals,
+    )
+    .expect("event carries a payload");
     assert!(!off
         .metadata
         .keys()
         .any(|key| crate::canonical_message::is_source_metadata_key(key)));
 
-    let on =
-        super::readers::MongoDbChangeStreamReader::event_to_message(&event, true, "shop.orders")
-            .expect("event carries a payload");
+    let on = super::readers::MongoDbChangeStreamReader::event_to_message(
+        &event,
+        true,
+        "shop.orders",
+        &ordinals,
+    )
+    .expect("event carries a payload");
     assert_eq!(
         on.metadata
             .get("mqb.src.mongodb_namespace")
@@ -46,6 +55,29 @@ fn change_event_source_metadata_is_opt_in_and_orders_by_cluster_time() {
         Some(((1_700_000_000u64 << 32) | 3).to_string()).as_deref()
     );
     assert!(on.metadata.contains_key("mqb.src.mongodb_resume_token"));
+    // First change seen at this cluster time.
+    assert_eq!(
+        on.metadata
+            .get("mqb.src.mongodb_ordinal")
+            .map(String::as_str),
+        Some("0")
+    );
+
+    // A second change in the same transaction gets the next ordinal, so an idempotent
+    // sink can name them as one contiguous range instead of colliding.
+    let next = super::readers::MongoDbChangeStreamReader::event_to_message(
+        &event,
+        true,
+        "shop.orders",
+        &ordinals,
+    )
+    .expect("event carries a payload");
+    assert_eq!(
+        next.metadata
+            .get("mqb.src.mongodb_ordinal")
+            .map(String::as_str),
+        Some("1")
+    );
 }
 
 #[test]
@@ -55,6 +87,7 @@ fn snapshot_source_metadata_uses_namespace_and_document_id() {
         &mut message,
         "shop.orders",
         &mongodb::bson::Bson::String("order-42".into()),
+        &std::sync::Mutex::new(super::readers::OrdinalCounter::default()),
     );
 
     assert_eq!(
@@ -70,6 +103,13 @@ fn snapshot_source_metadata_uses_namespace_and_document_id() {
             .get("mqb.src.mongodb_document_id")
             .map(String::as_str),
         Some("\"order-42\"")
+    );
+    assert_eq!(
+        message
+            .metadata
+            .get("mqb.src.mongodb_snapshot_index")
+            .map(String::as_str),
+        Some("0")
     );
 }
 

--- a/src/endpoints/object_store.rs
+++ b/src/endpoints/object_store.rs
@@ -9,9 +9,17 @@
 //! - **Sink** ([`ObjectStorePublisher`]): each flushed batch is encoded (reusing the
 //!   file endpoint's [`FileFormat`] codecs) and written as one immutable object at
 //!   `<prefix>/[YYYY/MM/DD/]<uuidv7>.<ext>`. Objects are write-once; nothing is appended
-//!   or mutated. The uuidv7 name sorts by write time to *millisecond* granularity only —
-//!   `rand_a`/`rand_b` are random, so objects written within the same millisecond sort in
-//!   arbitrary order. The date prefix is a readability / lifecycle-rule convenience only.
+//!   or mutated. The date prefix is a readability / lifecycle-rule convenience only.
+//!
+//!   **Object order holds only at `concurrency: 1`.** Lexicographic key order is the only
+//!   ordering a bucket offers. The keys are strictly increasing per publisher, so a
+//!   sequential route writes them in source order — but the key is minted inside
+//!   `send_batch`, which the worker pool runs concurrently, so above `concurrency: 1` mint
+//!   order is worker arrival order. Replaying a CDC stream through such a bucket can then
+//!   reorder UPDATE/DELETE events on the same key and yield a silently wrong final state.
+//!   Set `idempotency: true` to get source-sequenced names
+//!   (`part-<topic>-<partition>-<start>-<end>.<ext>`, zero-padded) for sources that stamp a
+//!   position; those sort by source position regardless of write order, at any concurrency.
 //! - **Source** ([`ObjectStoreConsumer`]): objects under `prefix` are listed in key order,
 //!   fetched whole, split by `delimiter`, and emitted. Progress is a durable cursor holding
 //!   the last fully-acked object key (via the external checkpoint store), so a restart
@@ -31,13 +39,14 @@ use crate::traits::{
 use crate::CanonicalMessage;
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
+use fast_uuid_v7::SequentialGenerator;
 use futures::StreamExt;
 use object_store::{
     path::Path as ObjPath, Error as ObjectStoreError, ObjectStore, ObjectStoreExt, PutMode,
     PutOptions, PutPayload,
 };
 use std::any::Any;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::{debug, info, trace, warn};
@@ -199,6 +208,9 @@ pub struct ObjectStorePublisher {
     extension: String,
     idempotency: bool,
     covered_ranges: Arc<Mutex<CoveredRanges>>,
+    // Shared across clones on purpose: the ordering guarantee is per generator instance, so
+    // two independent generators would hand out interleaved keys.
+    keys: Arc<StdMutex<SequentialGenerator>>,
 }
 
 impl ObjectStorePublisher {
@@ -252,16 +264,24 @@ impl ObjectStorePublisher {
             extension,
             idempotency: config.idempotency,
             covered_ranges: Arc::new(Mutex::new(covered_ranges)),
+            keys: Arc::new(StdMutex::new(SequentialGenerator::new())),
         })
     }
 
     /// Object key for the next write: `<prefix>/[YYYY/MM/DD/]<uuidv7>.<ext>`.
     ///
-    /// The uuidv7 name already sorts by write time; the optional date prefix is derived
+    /// The ids are strictly increasing per publisher, so key order is allocation order even
+    /// for objects written within the same millisecond. The optional date prefix is derived
     /// from that same id's embedded millisecond timestamp (no wall-clock dependency), so
-    /// the folder and the name can never disagree.
+    /// the folder and the name can never disagree. A backwards clock jump therefore keeps
+    /// writing under the pre-jump date until the clock catches up, rather than breaking the
+    /// key ordering.
     fn next_key(&self) -> ObjPath {
-        let id = fast_uuid_v7::gen_id();
+        let id = self
+            .keys
+            .lock()
+            .expect("Object-store key generator mutex poisoned")
+            .next_id();
         let name = format!("{}.{}", fast_uuid_v7::format_uuid(id), self.extension);
         if self.date_partition {
             // Top 48 bits of a uuidv7 are the Unix-epoch millisecond timestamp.
@@ -419,10 +439,10 @@ impl MessagePublisher for ObjectStorePublisher {
         Ok(())
     }
 
-    // Deliberately *not* declaring `requires_ordered_publish()`. Unlike the file sink, read
-    // order here is key order, and `next_key` randomises everything below the millisecond, so
-    // sequencing the writes would cost a latency-bound sink its concurrency without buying an
-    // ordering guarantee. Ordered cloud export needs a source-sequenced key first.
+    // Deliberately *not* declaring `requires_ordered_publish()`. Read order here is key order
+    // and `next_key` now hands out strictly increasing keys, but it allocates them inside
+    // `send_batch`, so at concurrency > 1 that order is worker arrival, not source order.
+    // Ordered cloud export needs the key allocated while the batches are still sequenced.
 
     fn as_any(&self) -> &dyn Any {
         self
@@ -861,8 +881,22 @@ impl MessageConsumer for ObjectStoreConsumer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::support::source_ranges::SourcePartition;
     use crate::traits::{MessageConsumer, MessagePublisher};
     use object_store::memory::InMemory;
+
+    /// Key an idempotent write lands on, derived rather than spelled out: the part-name
+    /// format is pinned by the `source_ranges` tests, not by these.
+    fn part_key(start: u64, end: u64, extension: &str) -> ObjPath {
+        let source = SourcePartition {
+            topic: "orders".to_string(),
+            partition: 0,
+        };
+        ObjPath::from(format!(
+            "data/{}",
+            finalized_name(&source, start, end, extension).unwrap()
+        ))
+    }
 
     #[test]
     fn checkpoint_overlap_detection() {
@@ -944,7 +978,22 @@ mod tests {
             extension: "jsonl".to_string(),
             idempotency: false,
             covered_ranges: Arc::new(Mutex::new(CoveredRanges::default())),
+            keys: Arc::new(StdMutex::new(SequentialGenerator::new())),
         }
+    }
+
+    #[test]
+    fn object_keys_sort_in_allocation_order_across_clones() {
+        let publisher = test_publisher(Arc::new(InMemory::new()));
+        let clone = publisher.clone();
+        let keys: Vec<String> = (0..1000)
+            .map(|i| {
+                if i % 2 == 0 { &publisher } else { &clone }
+                    .next_key()
+                    .to_string()
+            })
+            .collect();
+        assert!(keys.windows(2).all(|pair| pair[0] < pair[1]));
     }
 
     fn kafka_message(offset: i64) -> CanonicalMessage {
@@ -959,6 +1008,55 @@ mod tests {
             .metadata
             .insert("mqb.src.kafka_offset".into(), offset.to_string());
         message
+    }
+
+    /// The guarantee the idempotent sink exists to make, and the one the whole ordering
+    /// thread turns on: object order is *source* order even when batches are written
+    /// concurrently and out of order. Dispatches the batches in reverse and lets them race,
+    /// which is what the worker pool does to source order above `concurrency: 1`.
+    #[tokio::test]
+    async fn idempotent_objects_replay_in_source_order_when_written_concurrently() {
+        const BATCHES: i64 = 10;
+
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut publisher = test_publisher(store.clone());
+        publisher.idempotency = true;
+        // Raw writes the payload verbatim, so a record read back is the source row itself.
+        publisher.format = FileFormat::Raw;
+
+        let mut writes = tokio::task::JoinSet::new();
+        for batch in (0..BATCHES).rev() {
+            let publisher = publisher.clone();
+            writes.spawn(async move {
+                let base = batch * 2;
+                publisher
+                    .send_batch(vec![kafka_message(base), kafka_message(base + 1)])
+                    .await
+            });
+        }
+        while let Some(joined) = writes.join_next().await {
+            joined.unwrap().unwrap();
+        }
+
+        // Lexicographic listing is the only ordering a bucket offers, so that is what a
+        // reader gets and what this has to reproduce.
+        let mut stream = store.list(Some(&ObjPath::from("data")));
+        let mut names = Vec::new();
+        while let Some(item) = stream.next().await {
+            names.push(item.unwrap().location);
+        }
+        names.sort();
+        assert_eq!(names.len(), BATCHES as usize, "one part file per batch");
+
+        let mut replayed = Vec::new();
+        for name in &names {
+            let bytes = store.get(name).await.unwrap().bytes().await.unwrap();
+            for record in split_records(&bytes, b"\n") {
+                let value: serde_json::Value = serde_json::from_slice(record).unwrap();
+                replayed.push(value["offset"].as_i64().unwrap());
+            }
+        }
+        assert_eq!(replayed, (0..BATCHES * 2).collect::<Vec<_>>());
     }
 
     #[tokio::test]
@@ -1005,8 +1103,8 @@ mod tests {
             vec![
                 // Not a parseable part name, and not ours to delete.
                 "data/.stage-crash".to_string(),
-                "data/part-orders-0-0-1.jsonl".to_string(),
-                "data/part-orders-0-2-2.jsonl".to_string(),
+                part_key(0, 1, "jsonl").to_string(),
+                part_key(2, 2, "jsonl").to_string(),
             ]
         );
     }
@@ -1014,7 +1112,7 @@ mod tests {
     #[tokio::test]
     async fn idempotent_sink_does_not_overwrite_an_existing_range_object() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let key = ObjPath::from("data/part-orders-0-0-1.jsonl");
+        let key = part_key(0, 1, "jsonl");
         store
             .put(&key, PutPayload::from("already committed"))
             .await
@@ -1059,7 +1157,7 @@ mod tests {
             .unwrap();
 
         // The part name advertises the codec, and the bytes really are gzip.
-        let key = ObjPath::from("data/part-orders-0-0-1.jsonl.gz");
+        let key = part_key(0, 1, "jsonl.gz");
         let stored = store.get(&key).await.unwrap().bytes().await.unwrap();
         let plain =
             crate::support::compression::decompress_all(Compression::Gzip, &stored, None).unwrap();
@@ -1085,7 +1183,7 @@ mod tests {
         while let Some(item) = stream.next().await {
             names.push(item.unwrap().location.to_string());
         }
-        assert_eq!(names, vec!["data/part-orders-0-0-1.jsonl.gz".to_string()]);
+        assert_eq!(names, vec![part_key(0, 1, "jsonl.gz").to_string()]);
     }
 
     #[cfg(feature = "compression")]

--- a/src/endpoints/sqlx/mod.rs
+++ b/src/endpoints/sqlx/mod.rs
@@ -1983,6 +1983,7 @@ pub struct SqlxCursorReader {
     /// Page queries, built once: only the bound cursor and limit vary between polls.
     sql_first: String,
     sql_next: String,
+    source_metadata: bool,
 }
 
 /// Run one keyset page. `from` is the exclusive lower bound (`None` = start of table).
@@ -2004,6 +2005,13 @@ async fn fetch_page(
 
 impl SqlxCursorReader {
     pub async fn new(config: &SqlxConfig) -> anyhow::Result<Self> {
+        Self::new_with_source_metadata(config, config.source_metadata).await
+    }
+
+    pub async fn new_with_source_metadata(
+        config: &SqlxConfig,
+        source_metadata: bool,
+    ) -> anyhow::Result<Self> {
         sqlx::any::install_default_drivers();
         if config.delete_after_read {
             return Err(anyhow!(
@@ -2111,6 +2119,7 @@ impl SqlxCursorReader {
             ),
             checkpoint,
             last_value: Arc::new(Mutex::new(last_value)),
+            source_metadata,
         })
     }
 }
@@ -2122,6 +2131,46 @@ impl SqlxCursorReader {
         } else {
             &self.sql_first
         }
+    }
+
+    /// Stamp the replay position an idempotent sink names its objects from. The cursor value
+    /// *is* the position, so it has to be a unique non-negative integer: a text cursor has no
+    /// contiguous ordering, and a repeated value would make two rows resolve to the same
+    /// output record, silently dropping one. Rows arrive ordered, so ties are adjacent.
+    fn stamp_source_position(
+        &self,
+        message: &mut CanonicalMessage,
+        cursor: &SqlCursor,
+        previous: Option<&SqlCursor>,
+    ) -> Result<(), ConsumerError> {
+        let SqlCursor::Int(value) = cursor else {
+            return Err(ConsumerError::Permanent(anyhow!(
+                "source_metadata requires cursor_column '{}' to be an integer, but it read as \
+                 text. Point it at an integer key column, or CAST one in a view.",
+                self.cursor_column
+            )));
+        };
+        let value = u64::try_from(*value).map_err(|_| {
+            ConsumerError::Permanent(anyhow!(
+                "source_metadata requires cursor_column '{}' to be non-negative; got {value}.",
+                self.cursor_column
+            ))
+        })?;
+        if previous == Some(cursor) {
+            return Err(ConsumerError::Permanent(anyhow!(
+                "source_metadata requires cursor_column '{}' to be unique, but value {value} \
+                 repeats. Both rows would name the same output record and one would be dropped.",
+                self.cursor_column
+            )));
+        }
+
+        message
+            .metadata
+            .insert("mqb.src.sqlx_table".to_string(), self.table.clone());
+        message
+            .metadata
+            .insert("mqb.src.sqlx_cursor".to_string(), value.to_string());
+        Ok(())
     }
 }
 
@@ -2228,7 +2277,10 @@ impl MessageConsumer for SqlxCursorReader {
 
         let mut messages = Vec::with_capacity(fetched.len());
         let mut cursors: Vec<SqlCursor> = Vec::with_capacity(fetched.len());
-        for (cursor, msg) in fetched {
+        for (cursor, mut msg) in fetched {
+            if self.source_metadata {
+                self.stamp_source_position(&mut msg, &cursor, cursors.last())?;
+            }
             cursors.push(cursor.clone());
             messages.push(msg);
             // Advance optimistically so the next page continues past this row; rolled back

--- a/src/endpoints/sqlx/tests.rs
+++ b/src/endpoints/sqlx/tests.rs
@@ -1371,3 +1371,112 @@ async fn embedded_nul_in_a_bound_value_is_rejected() {
         .unwrap();
     assert_eq!(count, 0, "the row must not land at all");
 }
+
+// --- `source_metadata`: the polling cursor as a replay position ---
+
+#[tokio::test]
+async fn test_sqlx_cursor_reader_stamps_source_positions() {
+    use crate::support::source_ranges::SourcePosition;
+
+    let (_dir, url, _pool) = setup_arbitrary_table(3).await;
+    let config = SqlxConfig {
+        url,
+        table: "orders".to_string(),
+        cursor_column: Some("id".to_string()),
+        source_metadata: true,
+        ..Default::default()
+    };
+    let mut reader = SqlxCursorReader::new(&config).await.unwrap();
+
+    let batch = reader.receive_batch(3).await.unwrap();
+    assert_eq!(batch.messages.len(), 3);
+    assert_eq!(
+        batch.messages[0].metadata.get("mqb.src.sqlx_table"),
+        Some(&"orders".to_string())
+    );
+
+    // The cursor value is the offset itself, so the rows form one contiguous run and an
+    // idempotent sink names them as a single object.
+    let positions: Vec<u64> = batch
+        .messages
+        .iter()
+        .map(|m| SourcePosition::from_message(m).unwrap().offset)
+        .collect();
+    assert_eq!(positions, vec![1, 2, 3]);
+}
+
+/// A repeated cursor value would resolve two rows to one source position, and the sink
+/// drops the second. Reading it is what fails, not the silent drop later.
+#[tokio::test]
+async fn test_sqlx_cursor_reader_rejects_non_unique_cursor_for_source_metadata() {
+    sqlx::any::install_default_drivers();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("dup_meta.db");
+    let url = sqlite_url(&path);
+    drop(tokio::fs::File::create(&path).await.unwrap());
+    let pool = AnyPool::connect(&url).await.unwrap();
+    sqlx::query("CREATE TABLE events (id INTEGER PRIMARY KEY, ts INTEGER)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    for (id, ts) in [(1, 10), (2, 20), (3, 20)] {
+        sqlx::query("INSERT INTO events (id, ts) VALUES (?, ?)")
+            .bind(id)
+            .bind(ts)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    let config = SqlxConfig {
+        url,
+        table: "events".to_string(),
+        cursor_column: Some("ts".to_string()),
+        source_metadata: true,
+        ..Default::default()
+    };
+    let mut reader = SqlxCursorReader::new(&config).await.unwrap();
+
+    let err = reader.receive_batch(10).await.unwrap_err();
+    assert!(
+        matches!(err, ConsumerError::Permanent(_)),
+        "expected ConsumerError::Permanent, got {err:?}"
+    );
+    assert!(err.to_string().contains("unique"), "got: {err}");
+}
+
+/// A text cursor orders rows fine for paging but has no contiguous numeric position, so it
+/// cannot name an object range.
+#[tokio::test]
+async fn test_sqlx_cursor_reader_rejects_text_cursor_for_source_metadata() {
+    sqlx::any::install_default_drivers();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("text_meta.db");
+    let url = sqlite_url(&path);
+    drop(tokio::fs::File::create(&path).await.unwrap());
+    let pool = AnyPool::connect(&url).await.unwrap();
+    sqlx::query("CREATE TABLE events (k TEXT PRIMARY KEY, v INTEGER)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO events (k, v) VALUES ('a', 1)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let config = SqlxConfig {
+        url,
+        table: "events".to_string(),
+        cursor_column: Some("k".to_string()),
+        source_metadata: true,
+        ..Default::default()
+    };
+    let mut reader = SqlxCursorReader::new(&config).await.unwrap();
+
+    let err = reader.receive_batch(10).await.unwrap_err();
+    assert!(
+        matches!(err, ConsumerError::Permanent(_)),
+        "expected ConsumerError::Permanent, got {err:?}"
+    );
+    assert!(err.to_string().contains("integer"), "got: {err}");
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -865,7 +865,7 @@ pub struct FileConfig {
     /// Path to the file, or to the directory holding the part files when `idempotency` is true.
     pub path: String,
     /// Write replay-safe source ranges as immutable part files under this directory.
-    /// Requires Kafka source metadata or postgres_cdc commit LSN plus transaction ordinal metadata.
+    /// Requires a source that stamps a replayable position: kafka, postgres_cdc, mongodb CDC or file.
     #[serde(default)]
     pub idempotency: bool,
     /// Optional delimiter for messages. Defaults to newline ("\n").
@@ -885,6 +885,9 @@ pub struct FileConfig {
     /// At-rest AEAD encryption applied after compression. Requires the `encryption` feature. Publishers: always. Consumers: must match, and only the default `consume` mode reads it.
     #[serde(default)]
     pub encryption: Option<EncryptionConfig>,
+    /// (Consumer only) Include authoritative `mqb.src.file_*` source positions; only `consume` mode reproduces them across restarts. Defaults to false.
+    #[serde(default)]
+    pub source_metadata: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1937,6 +1940,9 @@ pub struct SqlxConfig {
     /// Needs table-owner privilege: it is auto-published `FOR TABLE {table}`.
     #[serde(default)]
     pub create_publication: bool,
+    /// (Consumer only) Include authoritative `mqb.src.sqlx_*` source positions; `cursor_column` must then be a unique integer. Defaults to false.
+    #[serde(default)]
+    pub source_metadata: bool,
     /// TLS configuration for the database connection.
     #[serde(default)]
     pub tls: TlsConfig,

--- a/src/models.rs
+++ b/src/models.rs
@@ -865,7 +865,7 @@ pub struct FileConfig {
     /// Path to the file, or to the directory holding the part files when `idempotency` is true.
     pub path: String,
     /// Write replay-safe source ranges as immutable part files under this directory.
-    /// Requires a source that stamps a replayable position: kafka, postgres_cdc, mongodb CDC or file.
+    /// Requires a source that stamps a replayable position: kafka, postgres_cdc, mongodb CDC, sqlx or file.
     #[serde(default)]
     pub idempotency: bool,
     /// Optional delimiter for messages. Defaults to newline ("\n").

--- a/src/models/builders.rs
+++ b/src/models/builders.rs
@@ -263,6 +263,7 @@ impl FileConfig {
             format: FileFormat::default(),
             compression: Compression::default(),
             encryption: None,
+            source_metadata: false,
         }
     }
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -5,7 +5,8 @@
 
 use crate::endpoints::{
     create_consumer_from_route, create_consumer_from_route_with_source_metadata,
-    create_publisher_from_route, output_requires_source_metadata,
+    create_publisher_from_route, output_has_write_ordered_object_store,
+    output_requires_source_metadata,
 };
 use crate::errors::ProcessingError;
 pub use crate::models::Route;
@@ -1312,6 +1313,16 @@ impl Route {
         drops: Option<&Arc<RwLock<DropReport>>>,
     ) -> anyhow::Result<bool> {
         let source_metadata_required = output_requires_source_metadata(name, &self.output)?;
+        if output_has_write_ordered_object_store(name, &self.output)? {
+            warn!(
+                route = name,
+                concurrency = self.options.concurrency,
+                "object_store sink names objects in write order, which this route's worker pool \
+                 makes arrival order rather than source order. Replaying a change stream through \
+                 the bucket can reorder updates to the same key. Set idempotency: true, or run \
+                 the route at concurrency: 1."
+            );
+        }
         let publisher = create_publisher_from_route(name, &self.output).await?;
         let mut consumer = create_consumer_from_route_with_source_metadata(
             name,

--- a/src/support/source_ranges.rs
+++ b/src/support/source_ranges.rs
@@ -396,8 +396,10 @@ pub fn finalized_name(
     // Zero-padded to fixed width so lexicographic listing order == numeric order.
     // `parse_finalized_name` still accepts legacy unpadded names.
     Ok(format!(
-        "part-{}-{:010}-{start:020}-{end:020}.{extension}",
-        source.topic, source.partition
+        "part-{topic}-{partition:010}-{start:0width$}-{end:0width$}.{extension}",
+        topic = source.topic,
+        partition = source.partition,
+        width = POSITION_WIDTH,
     ))
 }
 

--- a/src/support/source_ranges.rs
+++ b/src/support/source_ranges.rs
@@ -13,6 +13,19 @@ const OFFSET_KEY: &str = "mqb.src.kafka_offset";
 const POSTGRES_SLOT_KEY: &str = "mqb.src.postgres_slot";
 const POSTGRES_LSN_KEY: &str = "mqb.src.postgres_lsn";
 const POSTGRES_ORDINAL_KEY: &str = "mqb.src.postgres_ordinal";
+const MONGODB_NAMESPACE_KEY: &str = "mqb.src.mongodb_namespace";
+const MONGODB_CLUSTER_TIME_KEY: &str = "mqb.src.mongodb_cluster_time";
+const MONGODB_ORDINAL_KEY: &str = "mqb.src.mongodb_ordinal";
+const MONGODB_SNAPSHOT_INDEX_KEY: &str = "mqb.src.mongodb_snapshot_index";
+const FILE_PATH_KEY: &str = "mqb.src.file_path";
+const FILE_RECORD_KEY: &str = "mqb.src.file_record";
+const FILE_EPOCH_KEY: &str = "mqb.src.file_epoch";
+const SQLX_TABLE_KEY: &str = "mqb.src.sqlx_table";
+const SQLX_CURSOR_KEY: &str = "mqb.src.sqlx_cursor";
+
+/// Width of a `u64` embedded in a source key. Numbers inside the key must be fixed-width
+/// or ASCII sort disagrees with numeric sort and the sink replays out of order.
+const POSITION_WIDTH: usize = 20;
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct SourcePartition {
@@ -48,7 +61,20 @@ impl SourcePosition {
         {
             return Self::from_postgres_message(message);
         }
-        bail!("idempotent sink requires Kafka or postgres_cdc source-position metadata");
+        if message.metadata.contains_key(MONGODB_NAMESPACE_KEY) {
+            return Self::from_mongodb_message(message);
+        }
+        if message.metadata.contains_key(FILE_PATH_KEY)
+            || message.metadata.contains_key(FILE_RECORD_KEY)
+        {
+            return Self::from_file_message(message);
+        }
+        if message.metadata.contains_key(SQLX_TABLE_KEY)
+            || message.metadata.contains_key(SQLX_CURSOR_KEY)
+        {
+            return Self::from_sqlx_message(message);
+        }
+        bail!("idempotent sink requires Kafka, postgres_cdc, mongodb, file or sqlx source-position metadata");
     }
 
     fn from_kafka_message(message: &CanonicalMessage) -> Result<Self> {
@@ -84,13 +110,134 @@ impl SourcePosition {
         Ok(Self {
             // A commit LSN is shared by all changes in the transaction. Including it
             // in the source key makes the transaction ordinal a unique range offset.
+            // Padded: the LSN is part of the key text, so an unpadded one sorts
+            // 10000000000 before 9876543210.
             source: SourcePartition {
-                topic: format!("postgres_cdc-{slot}-{lsn}"),
+                topic: format!("postgres_cdc-{slot}-{lsn:00$}", POSITION_WIDTH),
                 partition: 0,
             },
             offset: ordinal,
         })
     }
+
+    /// MongoDB has two phases and they must sort in the order they are read: the initial
+    /// snapshot of existing documents, then the change stream. The phase is numbered into
+    /// the key (`0snapshot` before `1cdc`) so a change never replays ahead of the document
+    /// it modifies.
+    fn from_mongodb_message(message: &CanonicalMessage) -> Result<Self> {
+        let namespace = message
+            .metadata
+            .get(MONGODB_NAMESPACE_KEY)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("idempotent sink requires {MONGODB_NAMESPACE_KEY}"))?;
+
+        // Snapshot documents are paged by ascending `_id`, so their scan index is a
+        // contiguous, deterministic position.
+        if message.metadata.contains_key(MONGODB_SNAPSHOT_INDEX_KEY) {
+            let index = parse_unsigned_position(message, MONGODB_SNAPSHOT_INDEX_KEY)?;
+            return Ok(Self {
+                source: SourcePartition {
+                    topic: format!("mongodb-{namespace}-0snapshot"),
+                    partition: 0,
+                },
+                offset: index,
+            });
+        }
+
+        // A cluster time is shared by every change in a transaction, so it identifies the
+        // group and the ordinal positions the change inside it.
+        let cluster_time = parse_unsigned_position(message, MONGODB_CLUSTER_TIME_KEY)?;
+        let ordinal = parse_unsigned_position(message, MONGODB_ORDINAL_KEY)?;
+        Ok(Self {
+            source: SourcePartition {
+                topic: format!(
+                    "mongodb-{namespace}-1cdc-{cluster_time:00$}",
+                    POSITION_WIDTH
+                ),
+                partition: 0,
+            },
+            offset: ordinal,
+        })
+    }
+
+    /// The position is the record's index in the file, not its byte offset: the sink groups
+    /// records into one object by consecutive position, and byte offsets are never
+    /// consecutive, so they would force one object per record.
+    fn from_file_message(message: &CanonicalMessage) -> Result<Self> {
+        let path = message
+            .metadata
+            .get(FILE_PATH_KEY)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("idempotent sink requires {FILE_PATH_KEY}"))?;
+        let record = parse_unsigned_position(message, FILE_RECORD_KEY)?;
+        // Modes that do not start at byte 0 carry a run epoch, so a restart cannot reuse
+        // the record indexes of the run before it. Sorted ahead of the index because a
+        // later run always reads later records.
+        let identity = sanitize_path_identity(path);
+        let topic = match message.metadata.get(FILE_EPOCH_KEY) {
+            Some(_) => {
+                let epoch = parse_unsigned_position(message, FILE_EPOCH_KEY)?;
+                format!("file-{identity}-{epoch:00$}", POSITION_WIDTH)
+            }
+            None => format!("file-{identity}"),
+        };
+        Ok(Self {
+            source: SourcePartition {
+                topic,
+                partition: 0,
+            },
+            offset: record,
+        })
+    }
+
+    /// A polling cursor is a replay position in its own right, so the cursor value *is* the
+    /// offset — the same shape Kafka Connect's S3 sink uses for a Kafka offset. Only an
+    /// integer cursor reaches here; the reader rejects text cursors, which have no
+    /// contiguous ordering, before stamping.
+    fn from_sqlx_message(message: &CanonicalMessage) -> Result<Self> {
+        let table = message
+            .metadata
+            .get(SQLX_TABLE_KEY)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("idempotent sink requires {SQLX_TABLE_KEY}"))?;
+        let cursor = parse_unsigned_position(message, SQLX_CURSOR_KEY)?;
+
+        Ok(Self {
+            source: SourcePartition {
+                topic: format!("sqlx-{table}"),
+                partition: 0,
+            },
+            offset: cursor,
+        })
+    }
+}
+
+/// A source path is not usable as a key component verbatim — `finalized_name` rejects `/`,
+/// and object stores treat it as a directory separator. Keeps the file name for
+/// readability and appends a hash of the full path so two same-named files in different
+/// directories stay distinct.
+fn sanitize_path_identity(path: &str) -> String {
+    // FNV-1a, spelled out: `DefaultHasher` is explicitly not stable across Rust releases,
+    // and this digest goes into object names that must match after an upgrade.
+    let mut digest: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in path.as_bytes() {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+
+    let name = path.rsplit('/').next().unwrap_or(path);
+    let safe: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(64)
+        .collect();
+    format!("{safe}-{digest:016x}")
 }
 
 fn parse_signed_position(message: &CanonicalMessage, key: &str) -> Result<i64> {
@@ -246,8 +393,10 @@ pub fn finalized_name(
     {
         bail!("invalid idempotent sink finalized name components");
     }
+    // Zero-padded to fixed width so lexicographic listing order == numeric order.
+    // `parse_finalized_name` still accepts legacy unpadded names.
     Ok(format!(
-        "part-{}-{}-{start}-{end}.{extension}",
+        "part-{}-{:010}-{start:020}-{end:020}.{extension}",
         source.topic, source.partition
     ))
 }
@@ -309,6 +458,57 @@ mod tests {
         assert!(SourcePosition::from_message(&invalid).is_err());
     }
 
+    fn sqlx_message(table: &str, cursor: u64) -> CanonicalMessage {
+        let mut message = CanonicalMessage::new(b"payload".to_vec(), None);
+        message
+            .metadata
+            .insert(SQLX_TABLE_KEY.into(), table.to_string());
+        message
+            .metadata
+            .insert(SQLX_CURSOR_KEY.into(), cursor.to_string());
+        message
+    }
+
+    /// The cursor value is the offset directly, so consecutive rows coalesce into one run
+    /// and one object — a gap in the ids is what splits them.
+    #[test]
+    fn sqlx_cursor_positions_coalesce_consecutive_rows() {
+        let runs = CoveredRanges::default()
+            .uncovered_runs(vec![
+                sqlx_message("public.orders", 41),
+                sqlx_message("public.orders", 42),
+                sqlx_message("public.orders", 77),
+            ])
+            .unwrap();
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].source.topic, "sqlx-public.orders");
+        assert_eq!(
+            (runs[0].start, runs[0].end, runs[0].messages.len()),
+            (41, 42, 2)
+        );
+        assert_eq!((runs[1].start, runs[1].end), (77, 77));
+
+        // A schema-qualified table carries a `.`, which has to survive into a part name.
+        assert_eq!(
+            finalized_name(&runs[0].source, runs[0].start, runs[0].end, "jsonl").unwrap(),
+            "part-sqlx-public.orders-0000000000-00000000000000000041-00000000000000000042.jsonl"
+        );
+    }
+
+    #[test]
+    fn sqlx_cursor_positions_require_a_table_and_numeric_cursor() {
+        let mut missing_table = sqlx_message("orders", 1);
+        missing_table.metadata.remove(SQLX_TABLE_KEY);
+        assert!(SourcePosition::from_message(&missing_table).is_err());
+
+        let mut text_cursor = sqlx_message("orders", 1);
+        text_cursor
+            .metadata
+            .insert(SQLX_CURSOR_KEY.into(), "2026-08-18T00:00:00Z".into());
+        assert!(SourcePosition::from_message(&text_cursor).is_err());
+    }
+
     #[test]
     fn postgres_cdc_positions_preserve_each_change_in_a_commit() {
         let runs = CoveredRanges::default()
@@ -320,12 +520,18 @@ mod tests {
             .unwrap();
 
         assert_eq!(runs.len(), 2);
-        assert_eq!(runs[0].source.topic, "postgres_cdc-bridge_slot-9876543210");
+        assert_eq!(
+            runs[0].source.topic,
+            "postgres_cdc-bridge_slot-00000000009876543210"
+        );
         assert_eq!(
             (runs[0].start, runs[0].end, runs[0].messages.len()),
             (0, 1, 2)
         );
-        assert_eq!(runs[1].source.topic, "postgres_cdc-bridge_slot-9876543211");
+        assert_eq!(
+            runs[1].source.topic,
+            "postgres_cdc-bridge_slot-00000000009876543211"
+        );
         assert_eq!(
             (runs[1].start, runs[1].end, runs[1].messages.len()),
             (0, 0, 1)
@@ -367,8 +573,19 @@ mod tests {
             partition: 2,
         };
         let name = finalized_name(&source, 41, 59, "jsonl").unwrap();
-        assert_eq!(name, "part-orders-eu-2-41-59.jsonl");
-        assert_eq!(parse_finalized_name(&name, "jsonl"), Some((source, 41, 59)));
+        assert_eq!(
+            name,
+            "part-orders-eu-0000000002-00000000000000000041-00000000000000000059.jsonl"
+        );
+        assert_eq!(
+            parse_finalized_name(&name, "jsonl"),
+            Some((source.clone(), 41, 59))
+        );
+        // legacy unpadded names still read
+        assert_eq!(
+            parse_finalized_name("part-orders-eu-2-41-59.jsonl", "jsonl"),
+            Some((source, 41, 59))
+        );
         assert_eq!(
             parse_finalized_name(".stage-part-orders-2-41-59.jsonl", "jsonl"),
             None
@@ -381,6 +598,140 @@ mod tests {
             parse_finalized_name("part-orders-2-41-59.tmp", "jsonl"),
             None
         );
+    }
+
+    #[test]
+    fn finalized_names_sort_lexicographically_in_numeric_order() {
+        let ranges = [(0u64, 9u64), (10, 19), (99, 99), (100, 100), (100, 1000)];
+        for partition in [9i32, 10] {
+            let source = SourcePartition {
+                topic: "orders".into(),
+                partition,
+            };
+            let names = ranges
+                .iter()
+                .map(|(start, end)| finalized_name(&source, *start, *end, "jsonl").unwrap())
+                .collect::<Vec<_>>();
+            let mut sorted = names.clone();
+            sorted.sort();
+            assert_eq!(names, sorted);
+        }
+
+        let low = finalized_name(
+            &SourcePartition {
+                topic: "orders".into(),
+                partition: 9,
+            },
+            0,
+            0,
+            "jsonl",
+        )
+        .unwrap();
+        let high = finalized_name(
+            &SourcePartition {
+                topic: "orders".into(),
+                partition: 10,
+            },
+            0,
+            0,
+            "jsonl",
+        )
+        .unwrap();
+        assert!(low < high);
+    }
+
+    fn mongo_change(namespace: &str, cluster_time: u64, ordinal: u64) -> CanonicalMessage {
+        let mut message = CanonicalMessage::new(b"payload".to_vec(), None);
+        message
+            .metadata
+            .insert(MONGODB_NAMESPACE_KEY.into(), namespace.into());
+        message
+            .metadata
+            .insert(MONGODB_CLUSTER_TIME_KEY.into(), cluster_time.to_string());
+        message
+            .metadata
+            .insert(MONGODB_ORDINAL_KEY.into(), ordinal.to_string());
+        message
+    }
+
+    fn mongo_snapshot(namespace: &str, index: u64) -> CanonicalMessage {
+        let mut message = CanonicalMessage::new(b"payload".to_vec(), None);
+        message
+            .metadata
+            .insert(MONGODB_NAMESPACE_KEY.into(), namespace.into());
+        message
+            .metadata
+            .insert(MONGODB_SNAPSHOT_INDEX_KEY.into(), index.to_string());
+        message
+    }
+
+    fn file_record(path: &str, record: u64) -> CanonicalMessage {
+        let mut message = CanonicalMessage::new(b"payload".to_vec(), None);
+        message.metadata.insert(FILE_PATH_KEY.into(), path.into());
+        message
+            .metadata
+            .insert(FILE_RECORD_KEY.into(), record.to_string());
+        message
+    }
+
+    #[test]
+    fn mongodb_snapshot_sorts_before_the_change_stream_that_follows_it() {
+        let snapshot = SourcePosition::from_message(&mongo_snapshot("shop.orders", 0)).unwrap();
+        let change = SourcePosition::from_message(&mongo_change("shop.orders", 1, 0)).unwrap();
+        assert!(snapshot.source < change.source);
+
+        // The written names must sort the same way, or a change replays ahead of the
+        // document it modifies.
+        let snapshot_name = finalized_name(&snapshot.source, 0, 9, "jsonl").unwrap();
+        let change_name = finalized_name(&change.source, 0, 9, "jsonl").unwrap();
+        assert!(snapshot_name < change_name);
+    }
+
+    #[test]
+    fn mongodb_cluster_times_sort_numerically_across_digit_widths() {
+        let earlier = SourcePosition::from_message(&mongo_change("shop.orders", 9_999, 0)).unwrap();
+        let later = SourcePosition::from_message(&mongo_change("shop.orders", 10_000, 0)).unwrap();
+        assert!(
+            finalized_name(&earlier.source, 0, 0, "jsonl").unwrap()
+                < finalized_name(&later.source, 0, 0, "jsonl").unwrap()
+        );
+    }
+
+    #[test]
+    fn mongodb_changes_in_one_cluster_time_form_one_contiguous_run() {
+        let runs = CoveredRanges::default()
+            .uncovered_runs(vec![
+                mongo_change("shop.orders", 77, 0),
+                mongo_change("shop.orders", 77, 1),
+                mongo_change("shop.orders", 78, 0),
+            ])
+            .unwrap();
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!((runs[0].start, runs[0].end), (0, 1));
+        assert_eq!((runs[1].start, runs[1].end), (0, 0));
+    }
+
+    #[test]
+    fn file_records_form_one_run_and_distinguish_same_named_files() {
+        let runs = CoveredRanges::default()
+            .uncovered_runs(vec![
+                file_record("/data/in/orders.jsonl", 0),
+                file_record("/data/in/orders.jsonl", 1),
+                file_record("/data/in/orders.jsonl", 2),
+            ])
+            .unwrap();
+        // Consecutive record indexes coalesce into a single object; byte offsets would not.
+        assert_eq!(runs.len(), 1);
+        assert_eq!((runs[0].start, runs[0].end), (0, 2));
+
+        // Same file name, different directory: distinct partitions.
+        let a = SourcePosition::from_message(&file_record("/data/a/orders.jsonl", 0)).unwrap();
+        let b = SourcePosition::from_message(&file_record("/data/b/orders.jsonl", 0)).unwrap();
+        assert_ne!(a.source, b.source);
+
+        // The identity survives `finalized_name`'s rejection of path separators.
+        assert!(finalized_name(&a.source, 0, 2, "jsonl").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Description

 - fix object store sorting issue
 - use uuidv7 with ordered numbers for object_store names

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

<!-- Describe the tests you ran and how to verify your changes -->

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code
- [ ] Documentation updated (if needed)
- [ ] No new warnings generated
- [ ] Tests added/updated for new functionality
- [ ] All tests pass locally

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Related to #

## Additional Notes

<!-- Any additional information that reviewers should know -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional source metadata for file and SQL cursor inputs, including source positions and record identifiers.
  * Expanded idempotent delivery support to MongoDB CDC, file sources, and replayable SQL cursors.
  * Improved deterministic naming and ordering for idempotent object-store output, including compressed files.
  * Added stable metadata for MongoDB snapshots and change-stream events.

* **Bug Fixes**
  * Added warnings when concurrent processing may disrupt object-store write ordering.
  * Improved restart and replay behavior with source epochs and ordered ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->